### PR TITLE
[11.0][FIX] suspend security incorrect uid in env

### DIFF
--- a/base_suspend_security/__manifest__.py
+++ b/base_suspend_security/__manifest__.py
@@ -18,7 +18,7 @@
 ##############################################################################
 {
     "name": "Suspend security",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Therp BV, brain-tec AG, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Hidden/Dependency",

--- a/base_suspend_security/models/base.py
+++ b/base_suspend_security/models/base.py
@@ -12,4 +12,8 @@ class Base(models.AbstractModel):
 
     @api.model
     def suspend_security(self):
-        return self.sudo(user=BaseSuspendSecurityUid(self.env.uid))
+        return self.with_env(
+            api.Environment(
+                self.env.cr,
+                BaseSuspendSecurityUid(self.env.uid),
+                self.env.context))


### PR DESCRIPTION
When `sudo` is used, then Odoo converts `uid` to int, thus later it is not recognized as `BaseSuspendSecurityUid` instance

So, to avoid this conversion, new environment created (similary to that is happening in `sudo` call)