### PR TITLE
[11.0][FIX] base_external_dbsource_sqlite crashing when sqlparams equal None

### DIFF
--- a/base_external_dbsource_sqlite/__manifest__.py
+++ b/base_external_dbsource_sqlite/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'External Database Source - SQLite',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Tools',
     'author': "Daniel Reis, "
               "LasLabs, "

--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -51,7 +51,10 @@ class BaseExternalDbsource(models.Model):
         rows, cols = list(), list()
         for record in self:
             with record.connection_open() as connection:
-                cur = connection.execute(sqlquery, sqlparams)
+                if sqlparams is None:
+                    cur = connection.execute(sqlquery)
+                else:
+                    cur = connection.execute(sqlquery, sqlparams)
                 if metadata:
                     cols = list(cur.keys())
                 rows = [r for r in cur]

--- a/base_external_dbsource_sqlite/tests/test_base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/tests/test_base_external_dbsource.py
@@ -39,3 +39,12 @@ class TestBaseExternalDbsource(common.TransactionCase):
         ) as parent_method:
             self.dbsource.execute_sqlite(*expect)
             parent_method.assert_called_once_with(*expect)
+
+    def test_execute_sqlit_without_sqlparams(self):
+        """ It should pass args to SQLAlchemy execute """
+        expect = 'sqlquery', None, 'metadata'
+        with mock.patch.object(
+                self.dbsource, '_execute_sqlalchemy'
+        ) as parent_method:
+            self.dbsource.execute_sqlite(*expect)
+            parent_method.assert_called_once_with(*expect)


### PR DESCRIPTION
Module crashes when sqlparams variable in base_external_dbsource.py equals None.