### PR TITLE
[FIX] base_external_dbsource: Reuse Odoo DB settings for tests

### DIFF
--- a/base_external_dbsource/README.rst
+++ b/base_external_dbsource/README.rst
@@ -96,6 +96,7 @@ Contributors
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
 * Dave Lasley <dave@laslabs.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com> (https://wwww.tecnativa.com)
+* Jairo Llopis <jairo.llopis@tecnativa.com> (https://wwww.tecnativa.com)
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_external_dbsource/readme/CONTRIBUTORS.rst
+++ b/base_external_dbsource/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
 * Dave Lasley <dave@laslabs.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com> (https://wwww.tecnativa.com)
+* Jairo Llopis <jairo.llopis@tecnativa.com> (https://wwww.tecnativa.com)

--- a/base_external_dbsource/static/description/index.html
+++ b/base_external_dbsource/static/description/index.html
@@ -447,6 +447,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Gervais Naoussi &lt;<a class="reference external" href="mailto:gervaisnaoussi&#64;gmail.com">gervaisnaoussi&#64;gmail.com</a>&gt;</li>
 <li>Dave Lasley &lt;<a class="reference external" href="mailto:dave&#64;laslabs.com">dave&#64;laslabs.com</a>&gt;</li>
 <li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt; (<a class="reference external" href="https://wwww.tecnativa.com">https://wwww.tecnativa.com</a>)</li>
+<li>Jairo Llopis &lt;<a class="reference external" href="mailto:jairo.llopis&#64;tecnativa.com">jairo.llopis&#64;tecnativa.com</a>&gt; (<a class="reference external" href="https://wwww.tecnativa.com">https://wwww.tecnativa.com</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Before, postgres configuration was hardcoded. This worked OK for OCA's CI infrastructure, but failed in any other out there that had different defaults.

There's no need to hardcode it; Odoo already must have Postgres connection settings, so let's use those instead. This will make tests testable across different CI infrastructures.

@Tecnativa