### PR TITLE
[FIX] base_suspend_security when uid wrapper is used in One2many domain

### DIFF
--- a/base_suspend_security/__manifest__.py
+++ b/base_suspend_security/__manifest__.py
@@ -18,7 +18,7 @@
 ##############################################################################
 {
     "name": "Suspend security",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "author": "Therp BV, brain-tec AG, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Hidden/Dependency",

--- a/base_suspend_security/base_suspend_security.py
+++ b/base_suspend_security/base_suspend_security.py
@@ -30,6 +30,3 @@ class BaseSuspendSecurityUid(int):
 
     def __hash__(self):
         return super(BaseSuspendSecurityUid, self).__hash__()
-
-    def __iter__(self):
-        yield super(BaseSuspendSecurityUid, self).__int__()

--- a/base_suspend_security/models/res_users.py
+++ b/base_suspend_security/models/res_users.py
@@ -24,6 +24,13 @@ from ..base_suspend_security import BaseSuspendSecurityUid
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
+    def browse(self, arg=None, prefetch=None):
+        if isinstance(arg, BaseSuspendSecurityUid):
+            # Required to make _normalize_ids work
+            arg = super(BaseSuspendSecurityUid, arg).__int__()
+
+        return super(ResUsers, self).browse(arg=arg, prefetch=prefetch)
+
     @classmethod
     def _browse(cls, ids, env, prefetch=None, add_prefetch=True):
         """be sure we browse ints, ids laread is normalized"""

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -46,3 +46,28 @@ class TestBaseSuspendSecurity(TransactionCase):
         # this tests if _normalize_args conversion works
         self.env['res.users'].browse(
             self.env['res.users'].suspend_security().env.uid)
+        # Test normal search on One2many
+        partner = self.env['res.partner'].search(
+            [('user_ids.id', '=', self.env.user.suspend_security().env.uid)],
+            limit=1)
+        self.assertEqual(partner, self.env.user.partner_id)
+        # Test search on One2many without specifing ID (standard Odoo)
+        partner = self.env['res.partner'].search(
+            [('user_ids', '=', self.env.uid)],
+            limit=1)
+        self.assertEqual(partner, self.env.user.partner_id)
+        # Test search on One2many without specifing ID (suspend_security)
+        partner = self.env['res.partner'].search(
+            [('user_ids', '=', self.env.user.suspend_security().env.uid)],
+            limit=1)
+        self.assertEqual(partner, self.env.user.partner_id)
+        # Test search on One2many without ID with IN (standard Odoo)
+        partner = self.env['res.partner'].search(
+            [('user_ids', 'in', self.env.uid)],
+            limit=1)
+        self.assertEqual(partner, self.env.user.partner_id)
+        # Test search on One2many without ID with IN (suspend_security)
+        partner = self.env['res.partner'].search(
+            [('user_ids', 'in', self.env.user.suspend_security().env.uid)],
+            limit=1)
+        self.assertEqual(partner, self.env.user.partner_id)


### PR DESCRIPTION
Fix related to issue #36 

Suspend Security wrapper currently has method `__iter__`, and that's why following [expression](https://github.com/odoo/odoo/blob/11.0/odoo/osv/expression.py#L957)  evaluates to `True`:

```python
elif isinstance(right, collections.Iterable):
```
But later, following [code](https://github.com/odoo/odoo/blob/11.0/odoo/osv/expression.py#L443) tries to split that iterable by chunks, and raises error: 

```TypeError: object of type 'BaseSuspendSecurityUid' has no len().```

This PR fixes bug described above.