### PR TITLE
[FIX] base_user_role: Improve tests resiliency

### DIFF
--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -98,52 +98,54 @@ class TestUserRole(TransactionCase):
         self.assertEqual(user_group_ids, role_group_ids)
 
     def test_role_unlink(self):
-        # Get role1 groups
-        role1_group_ids = self.role1_id.implied_ids.ids
-        role1_group_ids.append(self.role1_id.group_id.id)
-        role1_group_ids = sorted(set(role1_group_ids))
-
+        # Get role1 and role2 groups
+        role1_groups = self.role1_id.implied_ids | self.role1_id.group_id
+        role2_groups = self.role2_id.implied_ids | self.role2_id.group_id
         # Configure the user with role1 and role2
         self.user_id.write(
             {'role_line_ids': [
                 (0, 0, {'role_id': self.role1_id.id}),
                 (0, 0, {'role_id': self.role2_id.id}),
             ]})
+        # Check user has groups from role1 and role2
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertLessEqual(role2_groups, self.user_id.groups_id)
         # Remove role2
         self.role2_id.unlink()
-        user_group_ids = sorted(set([
-            group.id for group in self.user_id.groups_id]))
-        self.assertEqual(user_group_ids, role1_group_ids)
+        # Check user has groups from only role1
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
         # Remove role1
         self.role1_id.unlink()
-        user_group_ids = sorted(set([
-            group.id for group in self.user_id.groups_id]))
-        self.assertEqual(user_group_ids, [])
+        # Check user has no groups from role1 and role2
+        self.assertFalse(role1_groups <= self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
 
     def test_role_line_unlink(self):
-        # Get role1 groups
-        role1_group_ids = self.role1_id.implied_ids.ids
-        role1_group_ids.append(self.role1_id.group_id.id)
-        role1_group_ids = sorted(set(role1_group_ids))
-
+        # Get role1 and role2 groups
+        role1_groups = self.role1_id.implied_ids | self.role1_id.group_id
+        role2_groups = self.role2_id.implied_ids | self.role2_id.group_id
         # Configure the user with role1 and role2
         self.user_id.write(
             {'role_line_ids': [
                 (0, 0, {'role_id': self.role1_id.id}),
                 (0, 0, {'role_id': self.role2_id.id}),
             ]})
+        # Check user has groups from role1 and role2
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertLessEqual(role2_groups, self.user_id.groups_id)
         # Remove role2 from the user
         self.user_id.role_line_ids.filtered(
             lambda l: l.role_id.id == self.role2_id.id).unlink()
-        user_group_ids = sorted(set([
-            group.id for group in self.user_id.groups_id]))
-        self.assertEqual(user_group_ids, role1_group_ids)
+        # Check user has groups from only role1
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
         # Remove role1 from the user
         self.user_id.role_line_ids.filtered(
             lambda l: l.role_id.id == self.role1_id.id).unlink()
-        user_group_ids = sorted(set([
-            group.id for group in self.user_id.groups_id]))
-        self.assertEqual(user_group_ids, [])
+        # Check user has no groups from role1 and role2
+        self.assertFalse(role1_groups <= self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
 
     def test_default_user_roles(self):
         self.default_user.write({


### PR DESCRIPTION
These 2 tests were checking the exact set of groups a user should have.

If these tests are ran in a database where a module is previously installed which adds more groups to the base role, these exact group sets would be inexact, although the behavior that is being tested was actually properly working.

With this patch, basically I'm testing if the user contains the groups from the roles, not the exact role set expected. It should work in integration scenarios.

@Tecnativa TT20468