### PR TITLE
12.0 fix search with suspend security

### DIFF
--- a/base_suspend_security/base_suspend_security.py
+++ b/base_suspend_security/base_suspend_security.py
@@ -4,9 +4,6 @@ from odoo.tools import pycompat
 
 
 class BaseSuspendSecurityUid(int):
-    def __int__(self):
-        return self
-
     def __eq__(self, other):
         if isinstance(other, pycompat.integer_types):
             return False

--- a/base_suspend_security/models/base.py
+++ b/base_suspend_security/models/base.py
@@ -1,7 +1,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, models, SUPERUSER_ID
 
 from ..base_suspend_security import BaseSuspendSecurityUid
 
@@ -17,3 +17,12 @@ class Base(models.AbstractModel):
                 self.env.cr,
                 BaseSuspendSecurityUid(self.env.uid),
                 self.env.context))
+
+    def sudo(self, user=SUPERUSER_ID):
+        if isinstance(self.env.uid, BaseSuspendSecurityUid):
+            return self.with_env(
+                api.Environment(
+                    self.env.cr, BaseSuspendSecurityUid(user), self.env.context
+                )
+            )
+        return super().sudo(user)

--- a/base_suspend_security/models/base.py
+++ b/base_suspend_security/models/base.py
@@ -19,10 +19,10 @@ class Base(models.AbstractModel):
                 self.env.context))
 
     def sudo(self, user=SUPERUSER_ID):
-        if isinstance(self.env.uid, BaseSuspendSecurityUid):
+        if isinstance(user, BaseSuspendSecurityUid):
             return self.with_env(
                 api.Environment(
-                    self.env.cr, BaseSuspendSecurityUid(user), self.env.context
+                    self.env.cr, user, self.env.context
                 )
             )
         return super().sudo(user)

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -30,3 +30,18 @@ class TestBaseSuspendSecurity(TransactionCase):
         # this tests if _normalize_args conversion works
         self.env['res.users'].browse(
             self.env['res.users'].suspend_security().env.uid)
+
+    def test_suspend_security_on_search(self):
+        user_without_access = self.env["res.users"].create(
+            dict(
+                name="Testing Suspend Security",
+                login="nogroups",
+                email="nogroups@suspendsecurity.com",
+                groups_id=[(5,)],
+            )
+        )
+        # the search is forbidden
+        with self.assertRaises(exceptions.AccessError):
+            self.env["ir.config_parameter"].sudo(user_without_access).search([])
+        # this tests the search
+        self.env["ir.config_parameter"].sudo(user_without_access).suspend_security().search([])

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -40,8 +40,9 @@ class TestBaseSuspendSecurity(TransactionCase):
                 groups_id=[(5,)],
             )
         )
+        model = self.env["ir.config_parameter"]
         # the search is forbidden
         with self.assertRaises(exceptions.AccessError):
-            self.env["ir.config_parameter"].sudo(user_without_access).search([])
+            model.sudo(user_without_access).search([])
         # this tests the search
-        self.env["ir.config_parameter"].sudo(user_without_access).suspend_security().search([])
+            model.sudo(user_without_access).suspend_security().search([])


### PR DESCRIPTION
Avoid Access Error when search with suspend security.

The Odoo `_search` function performs a  `sudo` on the first line of its
implementation, causing that the uid's wrapper (class BaseSuspendSecurityUid) is lost.

This is evidenced when a function with suspend security is called and in
its implementation needs the values ​​of a 'one2many' field (it does a
`search` in another model without reading access) an Access Error is raised.