### PR TITLE
12.0 fix syntax error on sql query

### DIFF
--- a/base_suspend_security/models/res_users.py
+++ b/base_suspend_security/models/res_users.py
@@ -12,8 +12,8 @@ class ResUsers(models.Model):
     def _browse(cls, ids, env, prefetch=None, add_prefetch=True):
         """be sure we browse ints, ids laread is normalized"""
         return super(ResUsers, cls)._browse(
-            [
+            models._normalize_ids([
                 i if not isinstance(i, BaseSuspendSecurityUid)
                 else super(BaseSuspendSecurityUid, i).__int__()
                 for i in ids
-            ], env, prefetch=prefetch, add_prefetch=add_prefetch)
+            ]), env, prefetch=prefetch, add_prefetch=add_prefetch)

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -29,8 +29,9 @@ class TestBaseSuspendSecurity(TransactionCase):
         self.assertEqual(other_company.name, 'test')
         self.assertEqual(other_company.write_uid.id, user_id)
         # this tests if _normalize_args conversion works
-        self.env['res.users'].browse(
+        user = self.env['res.users'].browse(
             self.env['res.users'].suspend_security().env.uid)
+        self.assertIsInstance(user._ids, tuple)
 
     def test_base_suspend_security_uid(self):
         """ Test corner cases of dunder functions """


### PR DESCRIPTION
Call super with normalized ids

self._ids is expected to be a tuple instance, using that on SQL queries
will raise a `psycopg2.ProgrammingError: syntax error at or near "ARRAY"`.