### PR TITLE
[FIX] base_user_role: ensure Channel autosubscription logic is applied

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -9,7 +9,12 @@
     "license": "AGPL-3",
     "maintainers": ["ABF OSIELL", "jcdrubay"],
     "website": "https://github.com/OCA/server-backend",
-    "depends": ["base"],
+    "depends": [
+        "base",
+        # Ensure Channel autosubscription logic runs
+        # after Groups are assigned
+        "mail",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "data/ir_cron.xml",


### PR DESCRIPTION
It could be the case where ``mail`` Channel autosubscription logic would
run before the Role logic added new groups to the User.
In that case, the autosubscrition logic would fail to apply.

Adding the ``mail`` dependency ensures this does not happen.

While the ``mail`` module in not required for the Role features,
it is a reasonable dependency to add, since it will be already
present in the vast majority of Odoo installations.