### PR TITLE
[13.0][FIX] check context value no_return for queries that don't return rows

### DIFF
--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -52,6 +52,8 @@ class BaseExternalDbsource(models.Model):
                     cur = connection.execute(sqlquery)
                 else:
                     cur = connection.execute(sqlquery, sqlparams)
+                if self.env.context.get('no_return', False):
+                    return rows, cols
                 if metadata:
                     cols = list(cur.keys())
                 rows = [r for r in cur]

--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -52,7 +52,7 @@ class BaseExternalDbsource(models.Model):
                     cur = connection.execute(sqlquery)
                 else:
                     cur = connection.execute(sqlquery, sqlparams)
-                if self.env.context.get('no_return', False):
+                if self.env.context.get("no_return", False):
                     return rows, cols
                 if metadata:
                     cols = list(cur.keys())


### PR DESCRIPTION
There are queries that could be executed using this method that don't return values, like inserts, updates, deletes and those will raise errors because there are no rows and cols to collect
This changes are to be able to avoid the errors bellow when collecting non-existing result rows

```log
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...
File "/Users/aek/git-workspace/server-backend/base_external_dbsource/models/base_external_dbsource.py", line 158, in execute rows, cols = method(query, execute_params, metadata)
File "/Users/aek/git-workspace/server-backend/base_external_dbsource_mssql/models/base_external_dbsource.py", line 42, in execute_mssql return self._execute_sqlalchemy(sqlquery, sqlparams, metadata)
File "/Users/aek/git-workspace/server-backend/base_external_dbsource_sqlite/models/base_external_dbsource.py", line 57, in _execute_sqlalchemy rows = [r for r in cur]
File "/Users/aek/git-workspace/server-backend/base_external_dbsource_sqlite/models/base_external_dbsource.py", line 57, in rows = [r for r in cur]
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/result.py", line 944, in iter row = self.fetchone()
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/result.py", line 1274, in fetchone e, None, None, self.cursor, self.context
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1475, in _handle_dbapi_exception util.reraise(*exc_info)
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 153, in reraise raise value
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/result.py", line 1266, in fetchone row = self._fetchone_impl()
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/result.py", line 1148, in _fetchone_impl return self._non_result(None)
File "/Users/aek/virtualenvs/odoo-13.0/venv/lib/python3.6/site-packages/sqlalchemy/engine/result.py", line 1168, in _non_result "This result object does not return rows. " sqlalchemy.exc.ResourceClosedError: This result object does not return rows. It has been closed automatically.
```