### PR TITLE
[12.0] check context value no_return

### DIFF
--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -55,6 +55,8 @@ class BaseExternalDbsource(models.Model):
                     cur = connection.execute(sqlquery)
                 else:
                     cur = connection.execute(sqlquery, sqlparams)
+                if self.env.context.get("no_return", False):
+                    return rows, cols
                 if metadata:
                     cols = list(cur.keys())
                 rows = [r for r in cur]


### PR DESCRIPTION
backport #78 
There are queries that could be executed using this method that don't return values, like inserts, updates, deletes and those will raise errors because there are no rows and cols to collect