### PR TITLE
[FIX] do not raise an error when default_user is not accessible by ir.rule

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -25,7 +25,7 @@ class ResUsers(models.Model):
         )
         default_values = []
         if default_user:
-            for role_line in default_user.role_line_ids:
+            for role_line in default_user.sudo().role_line_ids:
                 default_values.append(
                     {
                         "role_id": role_line.role_id.id,


### PR DESCRIPTION
Trivial Fix. 

when creating a user, we want to access to the role of the default user. if the user is not readable (due to ir.rule), the creation fails. This commit fixes the problem.