### PR TITLE
[FIX] Freezing mysqlclient version to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sqlalchemy
-mysqlclient
+mysqlclient==2.0.1
 pymssql<3.0


### PR DESCRIPTION
Backport of
-
https://github.com/OCA/server-backend/pull/99

Main
-
[FIX] Freezing mysqlclient version to 2.0.1 as more recent 2.0.2
makes the CI to fail


Explanation
-
Recently the CI has begun to fail with the following error in the tests:

```
MySQLdb/_mysql.c:1340:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for (unsigned int i=0; i<n; i++) {
         ^
    MySQLdb/_mysql.c:1340:5: note: use option -std=c99 or -std=gnu99 to compile your code
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

Following the trace it seems it is related to a failure with the server-backend project

```
subprocess.CalledProcessError: Command '['pip', 'install', '--no-binary', 'pycparser', '-Ur', '/root/server-backend/requirements.txt']' returned non-zero exit status 1
```

As it depends on: `mysqlclient` as reported [here](https://github.com/oca/server-backend/blob/12.0/requirements.txt#L2)

An a few hours ago that library was updated.

![Screen Shot 2020-12-10 at 0 39 22](https://user-images.githubusercontent.com/7598010/101736298-c9c49900-3a88-11eb-9ce5-5a05e5b6dc45.png)


Let us see if the attempt can fix it.

