### PR TITLE
[FIX][12.0] base_global_discount: prevent warning abount fields with same name

### DIFF
--- a/base_global_discount/models/res_partner.py
+++ b/base_global_discount/models/res_partner.py
@@ -27,8 +27,10 @@ class ResPartner(models.Model):
     customer_global_discount_ids_readonly = fields.Many2many(
         related="customer_global_discount_ids",
         readonly=True,
+        string='Sale Global Discounts (Readonly)',
     )
     supplier_global_discount_ids_readonly = fields.Many2many(
-        related="customer_global_discount_ids",
+        related="supplier_global_discount_ids",
         readonly=True,
+        string='Purchase Global Discounts (Readonly)',
     )

--- a/base_global_discount/views/res_partner_views.xml
+++ b/base_global_discount/views/res_partner_views.xml
@@ -8,16 +8,21 @@
          <field name="inherit_id" ref="base.view_partner_form"/>
          <field name="arch" type="xml">
             <group name="sale" position="inside">
-                <field name="customer_global_discount_ids" widget="many2many_tags" groups="base_global_discount.group_global_discount"
+                <field name="customer_global_discount_ids" widget="many2many_tags"
+                       groups="base_global_discount.group_global_discount"
                        attrs="{'invisible': [('customer', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
                 <field name="customer_global_discount_ids_readonly" widget="many2many_tags"
                        groups="!base_global_discount.group_global_discount"
+                       string="Sale Global Discounts"
                        attrs="{'invisible': [('customer', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
             </group>
             <group name="purchase" position="inside">
-                <field name="supplier_global_discount_ids" widget="many2many_tags" groups="base_global_discount.group_global_discount"
+                <field name="supplier_global_discount_ids" widget="many2many_tags"
+                       groups="base_global_discount.group_global_discount"
                        attrs="{'invisible': [('supplier', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
-                <field name="supplier_global_discount_ids" widget="many2many_tags" groups="!base_global_discount.group_global_discount"
+                <field name="supplier_global_discount_ids_readonly" widget="many2many_tags"
+                       groups="!base_global_discount.group_global_discount"
+                       string="Purchase Global Discounts"
                        attrs="{'invisible': [('supplier', '=', False), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
             </group>
          </field>


### PR DESCRIPTION
Hopefully, this will make runbot green. Also fixing some other inconsistencies.

```
2020-12-16 20:20:16,255 161 WARNING openerp_test odoo.addons.base.models.ir_model: Two fields (customer_global_discount_ids_readonly, customer_global_discount_ids) of res.partner() have the same label: Sale Global Discounts.
2020-12-16 20:20:16,255 161 WARNING openerp_test odoo.addons.base.models.ir_model: Two fields (supplier_global_discount_ids_readonly, customer_global_discount_ids) of res.partner() have the same label: Sale Global Discounts.
2020-12-16 20:20:16,315 161 WARNING openerp_test odoo.addons.base.models.ir_model: Two fields (customer_global_discount_ids_readonly, supplier_global_discount_ids_readonly) of res.users[] have the same label: Sale Global Discounts.
2020-12-16 20:20:16,315 161 WARNING openerp_test odoo.addons.base.models.ir_model: Two fields (customer_global_discount_ids, supplier_global_discount_ids_readonly) of res.users[] have the same label: Sale Global Discounts.
```