### PR TITLE
[FIX] base_user_role: remove multicompany functionality

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -3,8 +3,7 @@
 import datetime
 import logging
 
-from odoo import SUPERUSER_ID, _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import SUPERUSER_ID, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -89,23 +88,6 @@ class ResUsersRoleLine(models.Model):
     date_from = fields.Date("From")
     date_to = fields.Date("To")
     is_enabled = fields.Boolean("Enabled", compute="_compute_is_enabled")
-    company_id = fields.Many2one(
-        "res.company", "Company", default=lambda self: self.env.user.company_id
-    )
-
-    @api.constrains("user_id", "company_id")
-    def _check_company(self):
-        for record in self:
-            if (
-                record.company_id
-                and record.company_id != record.user_id.company_id
-                and record.company_id not in record.user_id.company_ids
-            ):
-                raise ValidationError(
-                    _('User "{}" does not have access to the company "{}"').format(
-                        record.user_id.name, record.company_id.name
-                    )
-                )
 
     @api.depends("date_from", "date_to")
     def _compute_is_enabled(self):

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -49,10 +49,7 @@ class ResUsers(models.Model):
         return res
 
     def _get_enabled_roles(self):
-        return self.role_line_ids.filtered(
-            lambda rec: rec.is_enabled
-            and (not rec.company_id or rec.company_id == rec.user_id.company_id)
-        )
+        return self.role_line_ids.filtered(lambda rec: rec.is_enabled)
 
     def set_groups_from_roles(self, force=False):
         """Set (replace) the groups following the roles defined on users.

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -48,9 +48,6 @@ class TestUserRole(TransactionCase):
         self.role2_id = self.role_model.create(vals)
         self.company1 = self.env.ref("base.main_company")
         self.company2 = self.env["res.company"].create({"name": "company2"})
-        self.user_id.write(
-            {"company_ids": [(4, self.company1.id, 0), (4, self.company2.id, 0)]}
-        )
 
     def test_role_1(self):
         self.user_id.write({"role_line_ids": [(0, 0, {"role_id": self.role1_id.id})]})
@@ -172,55 +169,3 @@ class TestUserRole(TransactionCase):
         )
         roles = self.role_model.browse([self.role1_id.id, self.role2_id.id])
         self.assertEqual(user.role_ids, roles)
-
-    def test_user_role_different_company(self):
-        self.user_id.write({"company_id": self.company1.id})
-        self.user_id.write(
-            {
-                "role_line_ids": [
-                    (
-                        0,
-                        0,
-                        {"role_id": self.role2_id.id, "company_id": self.company2.id},
-                    )
-                ]
-            }
-        )
-        # Check that user does not have any groups
-        self.assertEqual(self.user_id.groups_id, self.env["res.groups"].browse())
-
-    def test_user_role_same_company(self):
-        self.user_id.write({"company_id": self.company1.id})
-        self.user_id.write(
-            {
-                "role_line_ids": [
-                    (
-                        0,
-                        0,
-                        {"role_id": self.role1_id.id, "company_id": self.company1.id},
-                    )
-                ]
-            }
-        )
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        role_group_ids = self.role1_id.trans_implied_ids.ids
-        role_group_ids.append(self.role1_id.group_id.id)
-        role_group_ids = sorted(set(role_group_ids))
-        # Check that user have groups implied by role 1
-        self.assertEqual(user_group_ids, role_group_ids)
-
-    def test_user_role_no_company(self):
-        self.user_id.write({"company_id": self.company1.id})
-        self.user_id.write(
-            {
-                "role_line_ids": [
-                    (0, 0, {"role_id": self.role2_id.id, "company_id": False})
-                ]
-            }
-        )
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        role_group_ids = self.role2_id.trans_implied_ids.ids
-        role_group_ids.append(self.role2_id.group_id.id)
-        role_group_ids = sorted(set(role_group_ids))
-        # Check that user have groups implied by role 2
-        self.assertEqual(user_group_ids, role_group_ids)

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -27,10 +27,6 @@
                                     <field name="date_from" />
                                     <field name="date_to" />
                                     <field name="is_enabled" />
-                                    <field
-                                        name="company_id"
-                                        groups="base.group_multi_company"
-                                    />
                                 </tree>
                             </field>
                         </page>

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -16,10 +16,6 @@
                             <field name="date_from" />
                             <field name="date_to" />
                             <field name="is_enabled" />
-                            <field
-                                name="company_id"
-                                groups="base.group_multi_company"
-                            />
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Multicompany functionality is not the same in 14.0.

To illustrate:

![Screenshot from 2021-01-25 22-53-46](https://user-images.githubusercontent.com/19902174/105771009-3e339880-5f60-11eb-80f4-c64481aa736a.png)

Before, selecting one company or the other would change the user's company_id (in DB). Now, it's only a key in context.

So current multicompany functionality is broken and to be re-imagined later. This PR removes multicompany functionality.