### PR TITLE
[12.0][FIX] base_suspend_security: Pretend to be a list of ints if neccessary

### DIFF
--- a/base_suspend_security/base_suspend_security.py
+++ b/base_suspend_security/base_suspend_security.py
@@ -5,6 +5,8 @@ from odoo.tools import pycompat
 
 class BaseSuspendSecurityUid(int):
     def __eq__(self, other):
+        if isinstance(other, BaseSuspendSecurityUid):
+            return self * 1 == other * 1
         if isinstance(other, pycompat.integer_types):
             return False
         return super(BaseSuspendSecurityUid, self).__int__() == other

--- a/base_suspend_security/base_suspend_security.py
+++ b/base_suspend_security/base_suspend_security.py
@@ -14,3 +14,16 @@ class BaseSuspendSecurityUid(int):
 
     def __iter__(self):
         yield super(BaseSuspendSecurityUid, self).__int__()
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, key):
+        int_value = super().__int__()
+        if isinstance(key, slice):
+            if key.start > 0:
+                return ()
+            return (int_value,)
+        if key != 0:
+            raise IndexError
+        return int_value

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -55,7 +55,7 @@ class TestBaseSuspendSecurity(TransactionCase):
         with self.assertRaises(exceptions.AccessError):
             model.sudo(user_without_access).search([])
         # this tests the search
-            model.sudo(user_without_access).suspend_security().search([])
+        model.sudo(user_without_access).suspend_security().search([])
         # be sure we can search suspended uids like ints
         partners = self.env['res.partner'].with_context(
             active_test=False,

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -63,3 +63,13 @@ class TestBaseSuspendSecurity(TransactionCase):
             ('user_ids', '=', user_without_access.suspend_security().env.uid),
         ])
         self.assertTrue(partners)
+
+    def test_envs(self):
+        """ Test that we get the same env when suspending from the same env """
+        partner = self.env.ref('base.partner_demo')
+        user = self.env.ref('base.user_demo')
+        self.assertEqual(partner.env.args, user.env.args)
+        partner_suspended = partner.suspend_security()
+        user_suspended = user.suspend_security()
+        self.assertNotEqual(partner.env.args, partner_suspended.env.args)
+        self.assertEqual(user_suspended.env.args, partner_suspended.env.args)

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import exceptions
 from odoo.tests.common import TransactionCase
+from ..base_suspend_security import BaseSuspendSecurityUid
 
 
 class TestBaseSuspendSecurity(TransactionCase):
@@ -31,6 +32,15 @@ class TestBaseSuspendSecurity(TransactionCase):
         self.env['res.users'].browse(
             self.env['res.users'].suspend_security().env.uid)
 
+    def test_base_suspend_security_uid(self):
+        """ Test corner cases of dunder functions """
+        uid = BaseSuspendSecurityUid(42)
+        self.assertFalse(uid == 42)
+        self.assertEqual(uid[0], 42)
+        self.assertFalse(uid[1:])
+        with self.assertRaises(IndexError):
+            self.env['res.users'].browse(uid[1])
+
     def test_suspend_security_on_search(self):
         user_without_access = self.env["res.users"].create(
             dict(
@@ -46,3 +56,10 @@ class TestBaseSuspendSecurity(TransactionCase):
             model.sudo(user_without_access).search([])
         # this tests the search
             model.sudo(user_without_access).suspend_security().search([])
+        # be sure we can search suspended uids like ints
+        partners = self.env['res.partner'].with_context(
+            active_test=False,
+        ).search([
+            ('user_ids', '=', user_without_access.suspend_security().env.uid),
+        ])
+        self.assertTrue(partners)


### PR DESCRIPTION
when searching one2many fields, our uid ends up in the code branch for [iterables](https://github.com/OCA/OCB/blob/12.0/odoo/osv/expression.py#L973), so the uid needs to support [len and slicing](https://github.com/OCA/OCB/blob/12.0/odoo/osv/expression.py#L448)

The second commit is a forward port of a quite crucial [v8 feature](https://github.com/OCA/server-tools/pull/969), described in depth [later in the thread](https://github.com/OCA/server-tools/pull/969#issuecomment-330002605)