### PR TITLE
 [FIX] base_user_role: Do not drop groups, if user has no role_line_ids

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -112,6 +112,6 @@ class ResUsersRoleLine(models.Model):
     @api.multi
     def unlink(self):
         users = self.mapped("user_id")
-        res = super(ResUsersRoleLine, self).unlink()
-        users.set_groups_from_roles(force=True)
+        res = super().unlink()
+        users.filtered(lambda x: x.role_line_ids).set_groups_from_roles(force=True)
         return res

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -192,8 +192,8 @@ class TestUserRole(TransactionCase):
         self.user_id.role_line_ids.filtered(
             lambda l: l.role_id.id == self.role1_id.id
         ).unlink()
-        # Check user has no groups from role1 and role2
-        self.assertFalse(role1_groups <= self.user_id.groups_id)
+        # Keep user with the groups of role1
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
         self.assertFalse(role2_groups <= self.user_id.groups_id)
 
     def test_default_user_roles(self):


### PR DESCRIPTION
Proposing a patch that makes the module ``base_user_role`` safer IMO.

Step to reproduce : 
- Create role with groups
- affect a role to a user : the groups will be added / removed, to fit to the role.

before the PR : 
- remove the role : all the groups will be dropped.
it is so not possible to remove roles to "handle manually groups".

after the PR : 
- remove the role : the groups will be conserved.

Note : the PR changes the behaviour only if users doesn't have any roles, making the code consistent with that line :  https://github.com/OCA/server-backend/blob/12.0/base_user_role/models/user.py#L83

CC : @kevinkhao, @sebalix 