### PR TITLE
 [FIX] base_user_role : affect correct default category, when creating the related group

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "User roles",
-    "version": "12.0.2.0.1",
+    "version": "12.0.2.1.0",
     "category": "Tools",
     "author": "ABF OSIELL, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/base_user_role/data/ir_module_category.xml
+++ b/base_user_role/data/ir_module_category.xml
@@ -3,8 +3,9 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
-<record model="ir.module.category" id="ir_module_category_role">
-    <field name='name'>User roles</field>
-</record>
+    <record model="ir.module.category" id="ir_module_category_role">
+        <field name="name">User roles</field>
+        <field name="sequence">200</field>
+    </record>
 
 </odoo>

--- a/base_user_role/migrations/12.0.2.1.0/post-migration.py
+++ b/base_user_role/migrations/12.0.2.1.0/post-migration.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def _affect_group_to_category(env):
+    _logger.info("Set Category 'User roles' to groups related to roles")
+    roles = env["res.users.role"].search([])
+    groups = roles.mapped("group_id").filtered(lambda x: not x.category_id)
+    user_role_category = env.ref("base_user_role.ir_module_category_role")
+    groups.write({"category_id": user_role_category.id})
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _affect_group_to_category(env)

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -31,15 +31,17 @@ class ResUsersRole(models.Model):
         string="Users list",
         compute="_compute_user_ids",
     )
+    # TODO, remove in next version as it is not used in the whole module
+    # kept here for legacy reason
     group_category_id = fields.Many2one(
+        comodel_name="ir.module.category",
         related="group_id.category_id",
-        default=lambda cls: cls.env.ref(
-            "base_user_role.ir_module_category_role"
-        ).id,
         string="Associated category",
-        help="Associated group's category",
     )
     comment = fields.Html(string="Internal Notes")
+
+    def _default_category_id(self):
+        return self.env.ref("base_user_role.ir_module_category_role")
 
     @api.multi
     @api.depends("line_ids.user_id")
@@ -49,6 +51,8 @@ class ResUsersRole(models.Model):
 
     @api.model
     def create(self, vals):
+        if "category_id" not in vals and "group_id" not in vals:
+            vals.update({"category_id": self._default_category_id().id})
         new_record = super(ResUsersRole, self).create(vals)
         new_record.update_users()
         return new_record

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -297,3 +297,11 @@ class TestUserRole(SavepointCase):
         role_group_ids = sorted(set(role_group_ids))
         # Check that user have groups implied by role 2
         self.assertEqual(user_group_ids, role_group_ids)
+
+    def test_user_role_category(self):
+        # Check that groups created by role has the correct
+        # default category
+        self.assertEqual(
+            self.env.ref("base_user_role.ir_module_category_role").id,
+            self.role1_id.category_id.id
+        )


### PR DESCRIPTION
That PR fixes the module ``base_user_role``.

The module creates a ``ir.module.category`` for groups that are generated by roles. [See](https://github.com/OCA/server-backend/blob/12.0/base_user_role/data/ir_module_category.xml#L6).

**before that PR**

However, the current default + related design doesn't work. [See](https://github.com/OCA/server-backend/blob/12.0/base_user_role/models/role.py#L36). So the groups doesn't have a category, and are displayed in the "Other" section, with other "orphan" groups.

**After that PR**

- the module.category is displayed in the user form view
- all the groups are displayed in the correct section.

![image](https://user-images.githubusercontent.com/3407482/111297300-c293c500-864d-11eb-8952-a9b22b2e9be4.png)


Note 1 : ~~the patch provides a migration script to fix data on existing databases, pinned to ``12.0.3.0.0``. To maintainers : please call ocabot with ``major`` option.~~
EDIT :  the patch provides a migration script to fix data on existing databases, pinned to ``12.0.2.1.0``. To maintainers : please call ocabot with ``nobump`` option.

Note 2 : the test is written with the new design introduced by this PR #64 by @oerp-odoo. Once merged, the PR should be rebased to make travis green.

CC : @StefanRijnhart, @jcdrubay, @sebalix
