### PR TITLE
 [IMP] base_user_role : add wizard to preview group changes, when setting roles

### DIFF
--- a/base_user_role/__init__.py
+++ b/base_user_role/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -16,6 +16,7 @@
         "data/ir_module_category.xml",
         "views/role.xml",
         "views/user.xml",
+        "wizards/wizard_preview_change_user_role.xml",
     ],
     "installable": True,
 }

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -3,11 +3,22 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+    <record id="action_preview_role_changes" model="ir.actions.act_window">
+      <field name="name">Change Roles and Preview</field>
+      <field name="res_model">wizard.preview.change.user.role</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+    </record>
+
 <record id="view_res_users_form_inherit" model="ir.ui.view">
     <field name="name">res.users.form.inherit</field>
     <field name="model">res.users</field>
     <field name="inherit_id" ref="base.view_users_form"/>
     <field name="arch" type="xml">
+        <xpath expr="//header" position="inside">
+            <button name="%(action_preview_role_changes)d" type="action" string="Change Roles and Preview"/>
+        </xpath>
         <xpath expr="//notebook/page[1]" position="before">
             <page string="Roles">
                 <field name="role_line_ids" nolabel="1">

--- a/base_user_role/wizards/__init__.py
+++ b/base_user_role/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_preview_change_user_role

--- a/base_user_role/wizards/wizard_preview_change_user_role.py
+++ b/base_user_role/wizards/wizard_preview_change_user_role.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class WizardPreviewChangeUserRole(models.TransientModel):
+    _name = "wizard.preview.change.user.role"
+    _description = "Wizard Preview Change user Roles"
+
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        required=True,
+        default=lambda x: x._default_user_id(),
+    )
+
+    role_ids = fields.Many2many(
+        comodel_name="res.users.role"
+    )
+
+    hide_role_groups = fields.Boolean(
+        string="Hide Role Groups",
+        default=True,
+        help="If checked, the preview will exclude groups that are related"
+        " to roles."
+    )
+
+    added_group_ids = fields.Many2many(
+        comodel_name="res.groups",
+        compute="_compute_added_removed_group_ids",
+        store=False,
+        string="Groups to Add",
+        help="New groups that will be added, when applying role changes",
+    )
+
+    removed_group_ids = fields.Many2many(
+        comodel_name="res.groups",
+        compute="_compute_added_removed_group_ids",
+        store=False,
+        string="Groups to Remove",
+        help="Obsolete groups that will be removed, when applying role"
+        " changes",
+    )
+
+    def _default_user_id(self):
+        return self._context.get('active_id', False)
+
+    @api.multi
+    @api.depends("role_ids", "user_id", "hide_role_groups")
+    def _compute_added_removed_group_ids(self):
+        for wizard in self:
+            hidden_group_ids = []
+            if wizard.hide_role_groups:
+                all_roles = self.env["res.users.role"].search([])
+                hidden_group_ids = all_roles.mapped("group_id").ids
+
+            new_group_ids = list(
+                set(
+                    wizard.mapped("role_ids.group_id").ids
+                    + wizard.mapped("role_ids.implied_ids").ids
+                    + wizard.mapped("role_ids.trans_implied_ids").ids
+                )
+            )
+            current_group_ids = wizard.user_id.groups_id.ids
+            wizard.added_group_ids = list(
+                set(new_group_ids) - set(current_group_ids)
+                - set(hidden_group_ids))
+            wizard.removed_group_ids = list(
+                set(current_group_ids) - set(new_group_ids)
+                - set(hidden_group_ids))
+
+    def apply(self):
+        for wizard in self:
+            line_vals = [[5]]
+            line_vals += [
+                [
+                    0, 0, {
+                        "role_id": role.id,
+                    }
+                ] for role in wizard.role_ids
+            ]
+            wizard.user_id.write({"role_line_ids": line_vals})

--- a/base_user_role/wizards/wizard_preview_change_user_role.xml
+++ b/base_user_role/wizards/wizard_preview_change_user_role.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_wizard_preview_change_user_role_form" model="ir.ui.view">
+        <field name="model">wizard.preview.change.user.role</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="user_id" readonly="1"/>
+                    <field name="role_ids" widget="many2many_tags"/>
+                    <field name="hide_role_groups"/>
+                </group>
+                <group string="Groups to Add">
+                    <field name="added_group_ids" nolabel="1"/>
+                </group>
+                <group string="Groups to Remove">
+                    <field name="removed_group_ids" nolabel="1"/>
+                </group>
+                <footer>
+                    <button name="apply" string="Apply" type="object" class="oe_highlight"/>
+                    or
+                    <button string="Cancel" class="oe_link" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Hi all,

I'm trying to install and use ``base_user_role`` on an existing and quite complex database. (lot of users, that are not all well configured).
So I installed the module and created various roles.

When trying to affect role(s) to users, I'm still wondering what the real changes will be in terms of groups. (which groups will be added or removed).

For that purpose, this PR add a button on ``res.users`` form "Change Roles and Preview", that open a wizard. When selecting roles, the wizard will simulate the groups that will be added / removed if confirming the role.

**Exemple :**
- Role 1 : (Internal User + Multicompany)
- Role 2 : internal User + multi currency
- User demo : has role 2.


If user click on the button and select the role 1, the following wizard will display the changes that will be applied : 

![image](https://user-images.githubusercontent.com/3407482/111330159-fed81d00-866f-11eb-948f-3af530b9ee68.png)


