### PR TITLE
 [FIX] base_user_role : role lines are global by default

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -91,7 +91,7 @@ class ResUsersRoleLine(models.Model):
     date_to = fields.Date("To")
     is_enabled = fields.Boolean("Enabled", compute="_compute_is_enabled")
     company_id = fields.Many2one(
-        "res.company", "Company", default=lambda self: self.env.user.company_id
+        "res.company", "Company", default=False
     )
 
     @api.multi


### PR DESCRIPTION
Trivial patch. By default when using ``base_user_role`` in a multi company context, the expected functionality is that : 
affecting a role to a user apply the role for all the companies. (that is the odoo default functionnality). Filter per company should be an option.

This patch reset the default value.