### PR TITLE
[fix] requirements.txt: Pin pymssql to 2.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sqlalchemy
 radicale<3.0.0
 mysqlclient==2.0.1
-pymssql<3.0
+pymssql<=2.1.5


### PR DESCRIPTION
As the more recent version 2.2.0 is not compatible with Python 3.5.