### PR TITLE
Bypass check_field_access_rights when called with suspend_security

### DIFF
--- a/base_suspend_security/models/base.py
+++ b/base_suspend_security/models/base.py
@@ -26,3 +26,11 @@ class Base(models.AbstractModel):
                 )
             )
         return super().sudo(user)
+
+    @api.model
+    def check_field_access_rights(self, operation, fields):
+        # Handle suspend_security as if called with SUPERUSER_ID
+        if isinstance(self.env.uid, BaseSuspendSecurityUid):
+            return fields or list(self._fields)
+
+        return super().check_field_access_rights(operation, fields)


### PR DESCRIPTION
If a field is limited to specific groups, this restriction is NOT bypassed with suspend_security.

I think that using suspend_security() should be as close to using sudo() as possible, so I've added a few lines to bypass "check_field_access_rights" when called with suspend_security.

Any comments on this solution?