### PR TITLE
[FIX] base_import_match: "Unable to use a closed cursor"

### DIFF
--- a/base_import_match/models/base_import.py
+++ b/base_import_match/models/base_import.py
@@ -77,6 +77,7 @@ class BaseImportMatch(models.Model):
         """
         # Get usable rules to perform matches
         usable = self._usable_rules(model._name, converted_row)
+        usable = self.browse(usable)
         # Traverse usable combinations
         for combination in usable:
             combination_valid = True
@@ -126,7 +127,7 @@ class BaseImportMatch(models.Model):
         for record in available:
             if all(f.name in fields for f in record.field_ids):
                 result |= record
-        return result
+        return result.ids
 
 
 class BaseImportMatchField(models.Model):


### PR DESCRIPTION
Cached methods should never return recordsets, which are tied to specific context, env, cursor, uid. Instead, they should return IDs which, later, can be browsed in the current context.

With this change _usable_rules() cached method is now returing ids instead of a recordset, and also the _match_find method is properly browsing the results ids of the cached method.