### PR TITLE
[FIX] base_user_role_company: wrong xpath

### DIFF
--- a/base_user_role_company/views/role.xml
+++ b/base_user_role_company/views/role.xml
@@ -5,10 +5,13 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="base_user_role.view_res_users_form_inherit" />
         <field name="arch" type="xml">
-            <field name="role_id" position="after">
+            <xpath
+                expr="//field[@name='role_line_ids']//field[@name='role_id']"
+                position="after"
+            >
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="active_role" groups="base.group_no_one" readonly="1" />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
<pre>
Field "active_role" does not exist in model "res.users"

View name: res.users.form.inherit.company
Error context:
 view: ir.ui.view(2849,)
 xmlid: view_res_users_form_inherit_company
 view.model: res.users
 view.parent: ir.ui.view(2752,)
 file: /home/andrew/odoo/oca14/server-backend/base_user_role_company/views/role.xml
</pre>