### PR TITLE
[13.0][FIX] base_import_match - fix importing one2many records

### DIFF
--- a/base_import_match/models/base.py
+++ b/base_import_match/models/base.py
@@ -26,29 +26,33 @@ class Base(models.AbstractModel):
             # Mock Odoo to believe the user is importing the ID field
             if "id" not in fields:
                 fields.append("id")
-                import_fields.append(["id"])
             # Needed to match with converted data field names
-            clean_fields = [f[0] for f in import_fields]
             for dbid, xmlid, record, info in converted_data:
-                row = dict(zip(clean_fields, data[info["record"]]))
-                match = self
-                if xmlid:
-                    # Skip rows with ID, they do not need all this
-                    row["id"] = xmlid
-                    continue
-                elif dbid:
-                    # Find the xmlid for this dbid
-                    match = self.browse(dbid)
-                else:
-                    # Store records that match a combination
-                    match = self.env["base_import.match"]._match_find(self, record, row)
-                # Give a valid XMLID to this row if a match was found
-                # To generate externals IDS.
-                match.export_data(fields)
-                ext_id = match.get_external_id()
-                row["id"] = ext_id[match.id] if match else row.get("id", u"")
-                # Store the modified row, in the same order as fields
-                newdata.append(tuple(row[f] for f in clean_fields))
+                # In case of one2many on empty lines one record may contain several rows
+                for row_index in range(info["rows"]["from"], info["rows"]["to"] + 1):
+                    row = dict(zip(fields, data[row_index]))
+                    match = self
+                    if xmlid:
+                        # Skip rows with ID, they do not need all this
+                        row["id"] = xmlid
+                        continue
+                    elif dbid:
+                        # Find the xmlid for this dbid
+                        match = self.browse(dbid)
+                    elif row_index == info["rows"]["from"]:
+                        # Store records that match a combination
+                        # But only for first row of record,
+                        # because the rest contain one2many fields
+                        match = self.env["base_import.match"]._match_find(
+                            self, record, row
+                        )
+                    # Give a valid XMLID to this row if a match was found
+                    # To generate externals IDS.
+                    match.export_data(fields)
+                    ext_id = match.get_external_id()
+                    row["id"] = ext_id[match.id] if match else row.get("id", u"")
+                    # Store the modified row, in the same order as fields
+                    newdata.append(tuple(row[f] for f in fields))
             # We will import the patched data to get updates on matches
             data = newdata
         # Normal method handles the rest of the job

--- a/base_import_match/readme/CONTRIBUTORS.rst
+++ b/base_import_match/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
   * Jairo Llopis
   * Vicent Cubells
   * Ernesto Tejeda
+* Radovan Skolnik <radovan@skolnik.info>

--- a/base_import_match/tests/import_data/res_partner_email_one2many.csv
+++ b/base_import_match/tests/import_data/res_partner_email_one2many.csv
@@ -1,0 +1,4 @@
+email,function,child_ids/name,child_ids/color,child_ids/email
+floyd.steward34@example.com,Bug Fixer,Bart Steward,666,bart.steward@example.com
+,,Lisa Steward,777,lisa.steward@example.com
+,,Maggie Steward,555,maggie.steward@example.com

--- a/base_import_match/tests/test_import.py
+++ b/base_import_match/tests/test_import.py
@@ -68,3 +68,41 @@ class ImportCase(TransactionCase):
         record = self._base_import_record("res.users", "res_users_login")
         record.do(["login", "name"], [], OPTIONS)
         self.assertEqual(self.env.ref("base.user_demo").name, "Demo User Changed")
+
+    def test_res_partner_email_one2many(self):
+        """Change function based on email and import one2many record."""
+        record = self._base_import_record("res.partner", "res_partner_email_one2many")
+        record.do(
+            [
+                "email",
+                "function",
+                "child_ids/name",
+                "child_ids/color",
+                "child_ids/email",
+            ],
+            [],
+            OPTIONS,
+        )
+        self.assertEqual(
+            self.env.ref("base.res_partner_address_4").function, "Bug Fixer"
+        )
+        self.assertTrue(self.env.ref("base.res_partner_address_4").child_ids,)
+        self.assertEqual(
+            len(self.env.ref("base.res_partner_address_4").child_ids), 3,
+        )
+        self.assertEqual(
+            set(self.env.ref("base.res_partner_address_4").mapped("child_ids.name")),
+            {"Bart Steward", "Lisa Steward", "Maggie Steward"},
+        )
+        self.assertEqual(
+            set(self.env.ref("base.res_partner_address_4").mapped("child_ids.email")),
+            {
+                "bart.steward@example.com",
+                "lisa.steward@example.com",
+                "maggie.steward@example.com",
+            },
+        )
+        self.assertEqual(
+            set(self.env.ref("base.res_partner_address_4").mapped("child_ids.color")),
+            {666, 777, 555},
+        )


### PR DESCRIPTION
When trying to use `base_import_match` and importing related one2many records it fails badly with not really helpful message. Let's have a look at this code here:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L10-L31

Imagine we're importing `product.template` and have a rule setup to match `default_code`. We want to update `price` and also create new `product.supplierinfo` record - it is one2many attribute named named `seller_ids`. When mapped through import GUI something like this comes in:

```
fields = ['default_code', 'price', 'seller_ids/name/.id', 'seller_ids/min_qty', 'seller_ids/price', 'seller_ids/date_start']
data = [['TEST', '755', '11', '1', '566.25', '2022-01-18']]
```
That is all correct. Next comes these two lines:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L22-L25
Result of that is something like this:
```
import_fields = [['default_code'], ['price'], ['seller_ids', 'name', '.id'], ['seller_ids', 'min_qty'], ['seller_ids', 'price'], ['seller_ids', 'date_start']]

converted_data = 
[(False,
  False,
  {'default_code': 'TEST',
   'price': 755.0,
   'seller_ids': [(0,
                   False,
                   {'date_start': '2022-01-18',
                    'min_qty': 1.0,
                    'name': 11,
                    'price': 566.25})]},
  {'record': 0, 'rows': {'from': 0, 'to': 0}})]
```
So far so good. But then comes the part that ruins all:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L31
The result of that is something like this:
`clean_fields = ['default_code', 'price', 'seller_ids', 'seller_ids', 'seller_ids', 'seller_ids']`
The names of attributes of related record are all lost. This later leads to an attempt to map the same value (last of the related attribute?) to all related attributes:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L51

So this is an attempt to fix this. I have tested this through GUI as well as created a test case (not very pretty) that fails on original code.

@sbidoul @Yajo @pedrobaeza @sergio-teruel @zaoral @chienandalu please have a look. And have mercy on me please :-)