### PR TITLE
[13.0][FIX] base_import_match - fix importing one2many records

### DIFF
--- a/base_import_match/models/base.py
+++ b/base_import_match/models/base.py
@@ -28,9 +28,8 @@ class Base(models.AbstractModel):
                 fields.append("id")
                 import_fields.append(["id"])
             # Needed to match with converted data field names
-            clean_fields = [f[0] for f in import_fields]
             for dbid, xmlid, record, info in converted_data:
-                row = dict(zip(clean_fields, data[info["record"]]))
+                row = dict(zip(fields, data[info["record"]]))
                 match = self
                 if xmlid:
                     # Skip rows with ID, they do not need all this
@@ -48,7 +47,7 @@ class Base(models.AbstractModel):
                 ext_id = match.get_external_id()
                 row["id"] = ext_id[match.id] if match else row.get("id", u"")
                 # Store the modified row, in the same order as fields
-                newdata.append(tuple(row[f] for f in clean_fields))
+                newdata.append(tuple(row[f] for f in fields))
             # We will import the patched data to get updates on matches
             data = newdata
         # Normal method handles the rest of the job

--- a/base_import_match/readme/CONTRIBUTORS.rst
+++ b/base_import_match/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
   * Jairo Llopis
   * Vicent Cubells
   * Ernesto Tejeda
+* Radovan Skolnik <radovan@skolnik.info>

--- a/base_import_match/tests/import_data/res_partner_email_one2many.csv
+++ b/base_import_match/tests/import_data/res_partner_email_one2many.csv
@@ -1,0 +1,2 @@
+email,function,child_ids/name,child_ids/color,child_ids/email
+floyd.steward34@example.com,Bug Fixer,Floyd Stewart Jr.,666,floyd.steward.jr@example.com

--- a/base_import_match/tests/test_import.py
+++ b/base_import_match/tests/test_import.py
@@ -68,3 +68,33 @@ class ImportCase(TransactionCase):
         record = self._base_import_record("res.users", "res_users_login")
         record.do(["login", "name"], [], OPTIONS)
         self.assertEqual(self.env.ref("base.user_demo").name, "Demo User Changed")
+
+    def test_res_partner_email_one2many(self):
+        """Change function based on email and import one2many record."""
+        record = self._base_import_record("res.partner", "res_partner_email_one2many")
+        record.do(
+            [
+                "email",
+                "function",
+                "child_ids/name",
+                "child_ids/color",
+                "child_ids/email",
+            ],
+            [],
+            OPTIONS,
+        )
+        self.assertEqual(
+            self.env.ref("base.res_partner_address_4").function, "Bug Fixer"
+        )
+        self.assertTrue(self.env.ref("base.res_partner_address_4").child_ids,)
+        self.assertEqual(
+            self.env.ref("base.res_partner_address_4").child_ids[0].name,
+            "Floyd Stewart Jr.",
+        )
+        self.assertEqual(
+            self.env.ref("base.res_partner_address_4").child_ids[0].email,
+            "floyd.steward.jr@example.com",
+        )
+        self.assertEqual(
+            self.env.ref("base.res_partner_address_4").child_ids[0].color, 666
+        )


### PR DESCRIPTION
When trying to use `base_import_match` and importing related one2many records it fails badly with not really helpful message. Let's have a look at this code here:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L10-L31

Imagine we're importing `product.template` and have a rule setup to match `default_code`. We want to update `price` and also create new `product.supplierinfo` record - it is one2many attribute named named `seller_ids`. When mapped through import GUI something like this comes in:

```
fields = ['default_code', 'price', 'seller_ids/name/.id', 'seller_ids/min_qty', 'seller_ids/price', 'seller_ids/date_start']
data = [['TEST', '755', '11', '1', '566.25', '2022-01-18']]
```
That is all correct. Next comes these two lines:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L22-L25
Result of that is something like this:
```
import_fields = [['default_code'], ['price'], ['seller_ids', 'name', '.id'], ['seller_ids', 'min_qty'], ['seller_ids', 'price'], ['seller_ids', 'date_start']]

converted_data = 
[(False,
  False,
  {'default_code': 'TEST',
   'price': 755.0,
   'seller_ids': [(0,
                   False,
                   {'date_start': '2022-01-18',
                    'min_qty': 1.0,
                    'name': 11,
                    'price': 566.25})]},
  {'record': 0, 'rows': {'from': 0, 'to': 0}})]
```
So far so good. But then comes the part that ruins all:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L31
The result of that is something like this:
`clean_fields = ['default_code', 'price', 'seller_ids', 'seller_ids', 'seller_ids', 'seller_ids']`
The names of attributes of related record are all lost. This later leads to an attempt to map the same value (last of the related attribute?) to all related attributes:
https://github.com/OCA/server-backend/blob/0414dd0b0530389862a3da142b5642641c0cabfb/base_import_match/models/base.py#L51

So this is an attempt to fix this. I have tested this through GUI as well as created a test case (not very pretty) that fails on original code.

@sbidoul @Yajo @pedrobaeza @sergio-teruel @zaoral @chienandalu please have a look. And have mercy on me please :-)