### PR TITLE
[14.0][FIX] base_user_role: text on role Internal Notes was not saved

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -33,9 +33,6 @@ class ResUsersRole(models.Model):
         help="Associated group's category",
         readonly=False,
     )
-    comment = fields.Html(
-        string="Internal Notes",
-    )
 
     @api.depends("line_ids.user_id")
     def _compute_user_ids(self):


### PR DESCRIPTION
Editing the `comment`field on the form dis not work.
It  seems that this is because the field already exists in `res.groups` with the same name, and was being shadowed.