### PR TITLE
[14.0][FIX] base_user_role_company: wrong menus on re-login

### DIFF
--- a/base_user_role_company/__init__.py
+++ b/base_user_role_company/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2021 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import controllers
 from . import models

--- a/base_user_role_company/controllers/__init__.py
+++ b/base_user_role_company/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/base_user_role_company/controllers/main.py
+++ b/base_user_role_company/controllers/main.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import http
+
+from odoo.addons.web.controllers.main import Home
+
+
+class HomeExtended(Home):
+    @http.route()
+    def web_load_menus(self, unique):
+        response = super().web_load_menus(unique)
+        # On logout & re-login we could see wrong menus being rendered
+        # To avoid this, menu http cache must be disabled
+        response.headers.remove("Cache-Control")
+        return response


### PR DESCRIPTION
Issue found on logout / relogin.
The user groups were applied correctly, but the main menu showed apps
the user did not have access to.

This was related to the menu caching mechanisn, that was disabled here.