### PR TITLE
[13.0][IMP]base_user_role: Groups-roles navigation

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -17,6 +17,7 @@
         "data/ir_module_category.xml",
         "views/role.xml",
         "views/user.xml",
+        "views/group.xml",
     ],
     "installable": True,
 }

--- a/base_user_role/models/__init__.py
+++ b/base_user_role/models/__init__.py
@@ -1,2 +1,3 @@
 from . import role
 from . import user
+from . import group

--- a/base_user_role/models/group.py
+++ b/base_user_role/models/group.py
@@ -1,0 +1,82 @@
+from odoo import api, fields, models
+
+
+class ResGroups(models.Model):
+    _inherit = "res.groups"
+
+    # The inverse field of the field group_id on the res.users.role model
+    # This field should be used a One2one relation as a role can only be
+    # represented by one group. It's declared as a One2many field as the
+    # inverse field on the res.users.role it's declared as a Many2one
+    role_id = fields.One2many(
+        comodel_name="res.users.role",
+        inverse_name="group_id",
+        help="Relation for the groups that represents a role",
+    )
+
+    role_ids = fields.Many2many(
+        comodel_name="res.users.role",
+        relation="res_groups_implied_roles_rel",
+        string="Roles",
+        compute="_compute_role_ids",
+        help="Roles in which the group is involved",
+    )
+
+    parent_ids = fields.Many2many(
+        "res.groups",
+        "res_groups_implied_rel",
+        "hid",
+        "gid",
+        string="Parents",
+        help="Inverse relation for the Inherits field. "
+        "The groups from which this group is inheriting",
+    )
+
+    trans_parent_ids = fields.Many2many(
+        comodel_name="res.groups",
+        string="Parent Groups",
+        compute="_compute_trans_parent_ids",
+    )
+
+    role_count = fields = fields.Integer("# Roles", compute="_compute_role_count")
+
+    def _compute_role_count(self):
+        for group in self:
+            group.role_count = len(group.role_ids)
+
+    @api.depends("parent_ids.trans_parent_ids")
+    def _compute_trans_parent_ids(self):
+        for group in self:
+            group.trans_parent_ids = (
+                group.parent_ids | group.parent_ids.trans_parent_ids
+            )
+
+    def _compute_role_ids(self):
+        for group in self:
+            if group.trans_parent_ids:
+                group.role_ids = group.trans_parent_ids.role_id
+            else:
+                group.role_ids = group.role_id
+
+    def action_view_roles(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"].for_xml_id(
+            "base_user_role", "action_res_users_role_tree"
+        )
+        action["context"] = {}
+        if len(self.role_ids) > 1:
+            action["domain"] = [("id", "in", self.role_ids.ids)]
+        elif self.role_ids:
+            form_view = [
+                (self.env.ref("base_user_role.view_res_users_role_form").id, "form")
+            ]
+            if "views" in action:
+                action["views"] = form_view + [
+                    (state, view) for state, view in action["views"] if view != "form"
+                ]
+            else:
+                action["views"] = form_view
+            action["res_id"] = self.role_ids.id
+        else:
+            action = {"type": "ir.actions.act_window_close"}
+        return action

--- a/base_user_role/views/group.xml
+++ b/base_user_role/views/group.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="res_groups_view_form" model="ir.ui.view">
+        <field name="name">res.groups.form - base_user_role</field>
+        <field name="model">res.groups</field>
+        <field name="inherit_id" ref="base.view_groups_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/group" position="before">
+                <div name="button_box" class="oe_button_box">
+                    <button
+                        class="oe_stat_button"
+                        name="action_view_roles"
+                        type="object"
+                        icon="fa-gears"
+                        attrs="{'invisible': [ ('role_count', '=', 0)]}"
+                    >
+                        <field string="Roles" name="role_count" widget="statinfo" />
+                    </button>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR improves the module base_user_role, implementing the navigation from the groups to the roles. It's not implemented the other way around as the groups can already be accessed through the main view of any role.