### PR TITLE
[13.0][FIX]base_user_role: Add compute_sudo

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -13,7 +13,10 @@ class ResUsers(models.Model):
         default=lambda self: self._default_role_lines(),
     )
     role_ids = fields.One2many(
-        comodel_name="res.users.role", string="Roles", compute="_compute_role_ids"
+        comodel_name="res.users.role",
+        string="Roles",
+        compute="_compute_role_ids",
+        compute_sudo=True,
     )
 
     @api.model


### PR DESCRIPTION
@ForgeFlow
Add compute_sudo to avoid failure if any of the fields that the module is adding to the user is present in a tree view and the user has no rights to access the view.