### PR TITLE
[FIX] add external_dependencies_override for MySQLdb

### DIFF
--- a/setup/base_external_dbsource_mysql/setup.py
+++ b/setup/base_external_dbsource_mysql/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     odoo_addon={
         'external_dependencies_override': {
             'python': {
-                'MySQLdb': 'mysqlclient',
+                'MySQLdb': 'mysqlclient==2.0.1',
             }
         },
     }

--- a/setup/base_external_dbsource_mysql/setup.py
+++ b/setup/base_external_dbsource_mysql/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'MySQLdb': 'mysqlclient',
+            }
+        },
+    }
 )


### PR DESCRIPTION
this makes the branch build on runboat, see https://pypi.org/project/setuptools-odoo/#controlling-setuptools-odoo-behaviour