### PR TITLE
[13.0][FIX]base_user_role: Show active users on Users page

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -74,6 +74,7 @@ class ResUsersRoleLine(models.Model):
     _name = "res.users.role.line"
     _description = "Users associated to a role"
 
+    active = fields.Boolean(related="user_id.active")
     role_id = fields.Many2one(
         comodel_name="res.users.role", required=True, string="Role", ondelete="cascade"
     )

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -24,7 +24,7 @@ class ResUsers(models.Model):
         default_user = self.env.ref("base.default_user", raise_if_not_found=False)
         default_values = []
         if default_user:
-            for role_line in default_user.role_line_ids:
+            for role_line in default_user.with_context(active_test=False).role_line_ids:
                 default_values.append(
                     {
                         "role_id": role_line.role_id.id,


### PR DESCRIPTION
On the tree view of Roles, the number of users that is being shown is for active users, but once opening a Role, on the Users page of the form view, there are more users as it wasn't filtering for the active ones.

If there's a more elegant way to do it, please don't hesitate to correct me :smile: 