### PR TITLE
[14.0][FIX] base_user_role: Access Rights group is not enough to create Roles

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "User roles",
-    "version": "14.0.2.3.0",
+    "version": "14.0.2.3.1",
     "category": "Tools",
     "author": "ABF OSIELL, Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -41,7 +41,7 @@ class ResUsersRole(models.Model):
 
     @api.model
     def create(self, vals):
-        new_record = super(ResUsersRole, self).create(vals)
+        new_record = super(ResUsersRole, self.sudo()).create(vals)
         new_record.update_users()
         return new_record
 

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -180,3 +180,21 @@ class TestUserRole(TransactionCase):
         self.role1_id.write({"name": "foo", "comment": "FOO"})
         self.assertEqual(self.role1_id.group_id.name, "foo")
         self.assertEqual(self.role1_id.group_id.comment, "FOO")
+
+    def test_user_with_access_rights_can_create_role(self):
+        self.user_id.write(
+            {
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("base.group_erp_manager").id,
+                        ],
+                    )
+                ]
+            }
+        )
+        # user with group `base.group_erp_manager` (Access Rights) can create roles
+        self.role_model.with_user(self.user_id.id).create({"name": "ROLE_3"})


### PR DESCRIPTION
Fixes issue #156 "Access rights" group is not enough to create/edit Roles