### PR TITLE
[15.0][FIX] UserWarning: Field res.groups.trans_parent_ids should be …

### DIFF
--- a/base_user_role/models/res_groups.py
+++ b/base_user_role/models/res_groups.py
@@ -40,6 +40,7 @@ class ResGroups(models.Model):
         comodel_name="res.groups",
         string="Parent Groups",
         compute="_compute_trans_parent_ids",
+        recursive=True,
     )
 
     role_count = fields.Integer("# Roles", compute="_compute_role_count")


### PR DESCRIPTION
…declared with recursive=True

Source for the warning: https://github.com/odoo/odoo/blob/15.0/odoo/fields.py#L720-L722