### PR TITLE
[15.0][FIX] trans_parent_ids field declared recursive

### DIFF
--- a/base_user_role/models/res_groups.py
+++ b/base_user_role/models/res_groups.py
@@ -40,6 +40,7 @@ class ResGroups(models.Model):
         comodel_name="res.groups",
         string="Parent Groups",
         compute="_compute_trans_parent_ids",
+        recursive=True,
     )
 
     role_count = fields.Integer("# Roles", compute="_compute_role_count")


### PR DESCRIPTION
Solves this warning in our tests:
```
/data/build/odoo/odoo/fields.py:722: UserWarning: Field res.groups.trans_parent_ids should be declared with recursive=True
  File "odoo/odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "/data/build/odoo/odoo/cli/command.py", line 61, in main
    o.run(args)
  File "/data/build/odoo/odoo/cli/server.py", line 179, in run
    main(args)
  File "/data/build/odoo/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/data/build/odoo/odoo/service/server.py", line 1356, in start
    rc = server.run(preload, stop)
  File "/data/build/odoo/odoo/service/server.py", line 557, in run
    rc = preload_registries(preload)
  File "/data/build/odoo/odoo/service/server.py", line 1260, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/data/build/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/data/build/odoo/odoo/modules/loading.py", line 474, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/data/build/odoo/odoo/modules/loading.py", line 363, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/data/build/odoo/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/data/build/odoo/odoo/modules/registry.py", line 439, in init_models
    func()
  File "/data/build/odoo/odoo/addons/base/models/ir_model.py", line 45, in mark_modified
    records.modified(fnames)
  File "/data/build/odoo/odoo/models.py", line 5990, in modified
    node = self.pool.field_triggers.get(self._fields[fname])
  File "/data/build/odoo/odoo/tools/func.py", line 26, in __get__
    value = self.fget(obj)
  File "/data/build/odoo/odoo/modules/registry.py", line 337, in field_triggers
    dependencies[field] = OrderedSet(field.resolve_depends(self))
  File "/data/build/odoo/odoo/tools/misc.py", line 1043, in __init__
    self._map = dict.fromkeys(elems)
  File "/data/build/odoo/odoo/fields.py", line 722, in resolve_depends
    warnings.warn(f"Field {self} should be declared with recursive=True")
```