### PR TITLE
[DOC] base_user_role: set development status to 'Production/Stable'

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -8,6 +8,7 @@
     "category": "Tools",
     "author": "ABF OSIELL, Odoo Community Association (OCA)",
     "license": "LGPL-3",
+    "development_status": "Production/Stable",
     "maintainers": ["sebalix", "jcdrubay", "novawish"],
     "website": "https://github.com/OCA/server-backend",
     "depends": ["base"],


### PR DESCRIPTION
This module is used since a long time over quite a lot of Odoo versions, time to set a convenient development status.