### PR TITLE
12.0 - [REF] requirements.txt: Use "pymssql<=2.2.5" to fix "Failed building wheel for pymssql"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sqlalchemy
 mysqlclient==2.0.1
-pymssql
+pymssql<=2.2.5
 sqlparse

--- a/setup/base_external_dbsource_mssql/setup.py
+++ b/setup/base_external_dbsource_mssql/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'pymssql': 'pymssql<=2.2.5',
+            }
+        },
+    }
 )


### PR DESCRIPTION
The new `pymssql==2.2.6` version released this weekend
  - <img width="414" alt="Screenshot 2022-11-15 at 20 11 53" src="https://user-images.githubusercontent.com/6644187/202066666-a1551d22-d50a-4c14-ae0a-dd35dc147a40.png">

requires extra setup to be installed

So, it is raising new errors where it is not setup

You can reproduce it running the following command:

    docker run -it --rm  python:3.6 pip3 install -q pymssql==2.2.6

`ERROR: Could not build wheels for pymssql...`


```txt
ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmpmp6b33ly
       cwd: /tmp/pip-install-p4ocn1ip/pymssql_01748f191a744758bda6f7d536f6ec35
  Complete output (25 lines):
  setup.py: platform.system() => Linux
  setup.py: platform.architecture() => ('64bit', 'ELF')
  setup.py: platform.libc_ver() => ('glibc', '2.2.5')
  setup.py: include_dirs => []
  setup.py: library_dirs => []
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/pymssql
  copying src/pymssql/__init__.py -> build/lib.linux-x86_64-3.6/pymssql
  running build_ext
  cythoning src/pymssql/_mssql.pyx to src/pymssql/_mssql.c
  cythoning src/pymssql/_pymssql.pyx to src/pymssql/_pymssql.c
  building 'pymssql._mssql' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/src
  creating build/temp.linux-x86_64-3.6/src/pymssql
  gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.6m -c src/pymssql/_mssql.c -o build/temp.linux-x86_64-3.6/src/pymssql/_mssql.o -DMSDBLIB
  src/pymssql/_mssql.c:747:10: fatal error: sqlfront.h: No such file or directory
    747 | #include "sqlfront.h"
        |          ^~~~~~~~~~~~
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pymssql
ERROR: Could not build wheels for pymssql which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
FAIL
```

However, using 

    docker run -it --rm  python:3.6 pip3 install -q pymssql==2.2.5

It is installing well!

So, I have created this PR in order to fix all the error in the CI using this project and installing this package