### PR TITLE
[FIX] 12.0: base_external_dbsource_mssql pymssql 2.2.7 is fixed for python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sqlalchemy
 mysqlclient==2.0.1
-pymssql<=2.2.5
+pymssql
 sqlparse

--- a/setup/base_external_dbsource_mssql/setup.py
+++ b/setup/base_external_dbsource_mssql/setup.py
@@ -2,11 +2,5 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon={
-        'external_dependencies_override': {
-            'python': {
-                'pymssql': 'pymssql<=2.2.5',
-            }
-        },
-    }
+    odoo_addon=True,
 )


### PR DESCRIPTION
Revert "[REF] requirements.txt: Use "pymssql<=2.2.5" to fix "Failed building wheel for pymssql" (#195)"

- pymssql==2.2.7 is fixed for python 3.6 Check https://github.com/pymssql/pymssql/blob/master/ChangeLog.rst#version-227---2022-11-15----mikhail-terekhov

This reverts commit 0d4bf844dbe5bf549ce0e29119e96ef90dcbbfb3.