### PR TITLE
[FIX] AttributeError: 'str' object has no attribute '_execute_on_connection'

### DIFF
--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -30,12 +30,13 @@ class BaseExternalDbsource(models.Model):
 
     def _execute_sqlalchemy(self, sqlquery, sqlparams, metadata):
         rows, cols = list(), list()
+        exec_sqlquery = sqlalchemy.text(sqlquery)
         for record in self:
             with record.connection_open() as connection:
                 if sqlparams is None:
-                    cur = connection.execute(sqlquery)
+                    cur = connection.execute(exec_sqlquery)
                 else:
-                    cur = connection.execute(sqlquery, sqlparams)
+                    cur = connection.execute(exec_sqlquery, sqlparams)
                 if metadata:
                     cols = list(cur.keys())
                 rows = [r for r in cur]


### PR DESCRIPTION
Deprecated since version 2.0: passing a string to [Connection.execute()](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execute) is deprecated and will be removed in version 2.0. Use the [text()](https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.text) construct with [Connection.execute()](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execute), or the [Connection.exec_driver_sql()](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.exec_driver_sql) method to invoke a driver-level SQL string.

https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execute
