### PR TITLE
[FIX] base_user_role_company: remove role_id domain

### DIFF
--- a/base_user_role_company/__manifest__.py
+++ b/base_user_role_company/__manifest__.py
@@ -11,6 +11,7 @@
     "depends": ["base_user_role"],
     "data": [
         "views/role.xml",
+        "views/user.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/base_user_role_company/views/user.xml
+++ b/base_user_role_company/views/user.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2014 ABF OSIELL <http://osiell.com>
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+ -->
+<odoo>
+    <record id="view_res_users_form_inherit" model="ir.ui.view">
+        <field name="name">res.users.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base_user_role.view_res_users_form_inherit" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='role_id']" position="attributes">
+                <attribute name="domain" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit removes the domain added on role_id in base_user_role module.
The domain is not needed if we use this modules as we have to choose the same role for the multiple company

cc: @SodexisTeam 