### PR TITLE
Prevent exception if the query doesn't return rows

### DIFF
--- a/base_external_dbsource_sqlite/models/base_external_dbsource.py
+++ b/base_external_dbsource_sqlite/models/base_external_dbsource.py
@@ -38,5 +38,7 @@ class BaseExternalDbsource(models.Model):
                     cur = connection.execute(sqlquery, sqlparams)
                 if metadata:
                     cols = list(cur.keys())
-                rows = [r for r in cur]
+                # If the query doesn't return rows, trying to get them anyway 
+                # will raise an exception `sqlalchemy.exc.ResourceClosedError`
+                rows = [r for r in cur] if cur.returns_rows else []
         return rows, cols


### PR DESCRIPTION
Trying to get rows from the cursor when the query doesn't return rows will raise an exception.

```
sqlalchemy.exc.ResourceClosedError: This result object does not return rows. It has been closed automatically.
```
An example such request would for, by example, in mysql `SET some_variable = some_value`