### PR TITLE
[14.0][IMP] base_global_discount: added discount_base subtotal or total discount calculation

### DIFF
--- a/base_global_discount/i18n/base_global_discount.pot
+++ b/base_global_discount/i18n/base_global_discount.pot
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: base_global_discount
+#: model:ir.model.fields,help:base_global_discount.field_global_discount__discount_base
+msgid "Amount that will be discounted."
+msgstr ""
+
+#. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__company_id
 msgid "Company"
 msgstr ""
@@ -36,6 +41,11 @@ msgstr ""
 #. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__discount
 msgid "Discount"
+msgstr ""
+
+#. module: base_global_discount
+#: model:ir.model.fields,field_description:base_global_discount.field_global_discount__discount_base
+msgid "Discount Base"
 msgstr ""
 
 #. module: base_global_discount
@@ -136,4 +146,14 @@ msgstr ""
 #. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__sequence
 msgid "Sequence"
+msgstr ""
+
+#. module: base_global_discount
+#: model:ir.model.fields.selection,name:base_global_discount.selection__global_discount__discount_base__subtotal
+msgid "Subtotal"
+msgstr ""
+
+#. module: base_global_discount
+#: model:ir.model.fields.selection,name:base_global_discount.selection__global_discount__discount_base__total
+msgid "Total"
 msgstr ""

--- a/base_global_discount/i18n/it.po
+++ b/base_global_discount/i18n/it.po
@@ -19,7 +19,7 @@ msgstr ""
 #. module: base_global_discount
 #: model:ir.model.fields,help:base_global_discount.field_global_discount__discount_base
 msgid "Amount that will be discounted."
-msgstr "Importo che verr‡ scontato."
+msgstr "Importo che verr√† scontato."
 
 #. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__company_id

--- a/base_global_discount/i18n/it.po
+++ b/base_global_discount/i18n/it.po
@@ -17,6 +17,11 @@ msgstr ""
 "X-Generator: Weblate 4.17\n"
 
 #. module: base_global_discount
+#: model:ir.model.fields,help:base_global_discount.field_global_discount__discount_base
+msgid "Amount that will be discounted."
+msgstr "Importo che verrà scontato."
+
+#. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__company_id
 msgid "Company"
 msgstr "Azienda"
@@ -40,6 +45,11 @@ msgstr "Creato il"
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__discount
 msgid "Discount"
 msgstr "Sconto"
+
+#. module: base_global_discount
+#: model:ir.model.fields,field_description:base_global_discount.field_global_discount__discount_base
+msgid "Discount Base"
+msgstr "Base di Sconto"
 
 #. module: base_global_discount
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__name
@@ -140,3 +150,13 @@ msgstr "Vendite"
 #: model:ir.model.fields,field_description:base_global_discount.field_global_discount__sequence
 msgid "Sequence"
 msgstr "Sequenza"
+
+#. module: base_global_discount
+#: model:ir.model.fields.selection,name:base_global_discount.selection__global_discount__discount_base__subtotal
+msgid "Subtotal"
+msgstr "Totale Parziale"
+
+#. module: base_global_discount
+#: model:ir.model.fields.selection,name:base_global_discount.selection__global_discount__discount_base__total
+msgid "Total"
+msgstr "Totale"

--- a/base_global_discount/models/global_discount.py
+++ b/base_global_discount/models/global_discount.py
@@ -13,13 +13,13 @@ class GlobalDiscount(models.Model):
     discount = fields.Float(digits="Discount", required=True, default=0.0)
     discount_base = fields.Selection(
         selection=[
-            ('subtotal', 'Subtotal'),
-            ('total', 'Total'),
+            ("subtotal", "Subtotal"),
+            ("total", "Total"),
         ],
-        default='subtotal',
-        required='True',
-        string='Discount Base',
-        help='Amount that will be discounted.',
+        default="subtotal",
+        required="True",
+        string="Discount Base",
+        help="Amount that will be discounted.",
     )
     discount_scope = fields.Selection(
         selection=[("sale", "Sales"), ("purchase", "Purchases")],

--- a/base_global_discount/models/global_discount.py
+++ b/base_global_discount/models/global_discount.py
@@ -11,6 +11,16 @@ class GlobalDiscount(models.Model):
     sequence = fields.Integer(help="Gives the order to apply discounts")
     name = fields.Char(string="Discount Name", required=True)
     discount = fields.Float(digits="Discount", required=True, default=0.0)
+    discount_base = fields.Selection(
+        selection=[
+            ('subtotal', 'Subtotal'),
+            ('total', 'Total'),
+        ],
+        default='subtotal',
+        required='True',
+        string='Discount Base',
+        help='Amount that will be discounted.',
+    )
     discount_scope = fields.Selection(
         selection=[("sale", "Sales"), ("purchase", "Purchases")],
         default="sale",

--- a/base_global_discount/views/global_discount_views.xml
+++ b/base_global_discount/views/global_discount_views.xml
@@ -9,6 +9,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="discount" />
+                <field name="discount_base"/>
                 <field name="discount_scope" />
                 <field name="company_id" />
             </tree>
@@ -23,6 +24,7 @@
                         <field name="name" />
                         <field name="sequence" />
                         <field name="discount" />
+                        <field name="discount_base"/>
                         <field name="discount_scope" />
                         <field name="company_id" />
                     </group>

--- a/base_global_discount/views/global_discount_views.xml
+++ b/base_global_discount/views/global_discount_views.xml
@@ -9,7 +9,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="discount" />
-                <field name="discount_base"/>
+                <field name="discount_base" />
                 <field name="discount_scope" />
                 <field name="company_id" />
             </tree>
@@ -24,7 +24,7 @@
                         <field name="name" />
                         <field name="sequence" />
                         <field name="discount" />
-                        <field name="discount_base"/>
+                        <field name="discount_base" />
                         <field name="discount_scope" />
                         <field name="company_id" />
                     </group>


### PR DESCRIPTION
Like in the link in the following pull request https://github.com/OCA/account-invoicing/pull/1150, opened for the 12.0 version, also in the 14.0 version it is necessary to add the discount_base field for the calculation of the discount for the subtotal or for the total.