### PR TITLE
[FIX] base_user_role: Hide role fields from non-admin users.

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -11,12 +11,14 @@ class ResUsers(models.Model):
         inverse_name="user_id",
         string="Role lines",
         default=lambda self: self._default_role_lines(),
+        groups="base.group_erp_manager",
     )
     role_ids = fields.One2many(
         comodel_name="res.users.role",
         string="Roles",
         compute="_compute_role_ids",
         compute_sudo=True,
+        groups="base.group_erp_manager",
     )
 
     @api.model


### PR DESCRIPTION
This avoids an access error when a non-admin user attempts to view a list of users.

Steps to Reproduce:

1. --init=base_user_role,crm
2. Login as admin/admin
3. Create six test users
4. Create test role
5. Assign test role to some of the test users
6. Logout
7. Login as demo/demo
8. Edit a contact
9. On the Sales and Purchase tab, click into Salesperson and Search More...

FAIL: Access Error: You are not allowed to access 'User role' (res.users.role) records. This operation is allowed for the following groups: - Administration/Access Rights Contact your administrator to request access if necessary.