### PR TITLE
[FIX] base_user_role: Set group on access_wizard_groups_into_role

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "User roles",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     "category": "Tools",
     "author": "ABF OSIELL, Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/base_user_role/security/ir.model.access.csv
+++ b/base_user_role/security/ir.model.access.csv
@@ -2,4 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_res_users_role,access_res_users_role,model_res_users_role,"base.group_erp_manager",1,1,1,1
 access_res_users_role_line,access_res_users_role_line,model_res_users_role_line,"base.group_erp_manager",1,1,1,1
 access_wizard_create_role_from_user,access_wizard_create_role_from_user,model_wizard_create_role_from_user,"base.group_erp_manager",1,1,1,1
-access_wizard_groups_into_role,access_wizard_groups_into_role,model_wizard_groups_into_role,,1,1,1,1
+access_wizard_groups_into_role,access_wizard_groups_into_role,model_wizard_groups_into_role,"base.group_erp_manager",1,1,1,1


### PR DESCRIPTION
From 17.0 onwards, any access right rule with set permissions must have a group on it, otherwise it will throw a warning on install