### PR TITLE
[15.0][FIX] base_user_role: prevent crash when using 'res.users' (x2m) fields in forms

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -11,12 +11,14 @@ class ResUsers(models.Model):
         inverse_name="user_id",
         string="Role lines",
         default=lambda self: self._default_role_lines(),
+        groups="base.group_erp_manager",
     )
     role_ids = fields.One2many(
         comodel_name="res.users.role",
         string="Roles",
         compute="_compute_role_ids",
         compute_sudo=True,
+        groups="base.group_erp_manager",
     )
 
     @api.model


### PR DESCRIPTION
Prior to this commit, when `res.users` is added to a model as being a x2m field, the `advanced search` is causing an error.