### PR TITLE
[16.0][FW][FIX] base_user_role: prevent crash when using 'res.users' (x2m) fields in forms

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -11,6 +11,7 @@ class ResUsers(models.Model):
         inverse_name="user_id",
         string="Role lines",
         default=lambda self: self._default_role_lines(),
+        groups="base.group_erp_manager",
     )
 
     show_alert = fields.Boolean(compute="_compute_show_alert")
@@ -25,6 +26,7 @@ class ResUsers(models.Model):
         string="Roles",
         compute="_compute_role_ids",
         compute_sudo=True,
+        groups="base.group_erp_manager",
     )
 
     @api.model


### PR DESCRIPTION
Port of #300 from 15.0 to 16.0.