### PR TITLE
[15.0][FIX] change role_line_ids default value to override create

### DIFF
--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -211,6 +211,23 @@ class TestUserRole(TransactionCase):
         roles = self.role_model.browse([self.role1_id.id, self.role2_id.id])
         self.assertEqual(user.role_ids, roles)
 
+    def test_no_default_user(self):
+        self.default_user.unlink()
+        user = self.user_model.create(
+            {"name": "USER TEST (DEFAULT ROLES)", "login": "user_test_default_roles"}
+        )
+        self.assertFalse(user.role_ids)
+
+    def test_already_assigned_role(self):
+        user = self.user_model.create(
+            {
+                "name": "USER TEST (DEFAULT ROLES)",
+                "login": "user_test_default_roles",
+                "role_line_ids": [(0, 0, {"role_id": self.role1_id.id})],
+            }
+        )
+        self.assertEqual(len(user.role_ids), 1)
+
     def test_role_multicompany(self):
         """Test AccessError when admin-like user accesses a role"""
         role = self.multicompany_role.with_user(self.multicompany_user_1)


### PR DESCRIPTION
Populating role_line_ids this way doesn't work in this case. The previous method indeed return the right value but at creation, role_line_ids is empty in vals resulting of a new user having no role attributed even though the default_user has one. 

Feature already has test. Test added for coverage. 