### PR TITLE
[14.0] base_user_role: warning when adding admin to empty role

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -175,3 +175,16 @@ class ResUsersRoleLine(models.Model):
         res = super(ResUsersRoleLine, self).unlink()
         users.set_groups_from_roles(force=True)
         return res
+
+    @api.onchange("user_id")
+    def _onchange_user_id(self):
+        if self.user_id and self.user_id._is_admin():
+            return {
+                "warning": {
+                    "title": _("Warning"),
+                    "message": _(
+                        """When adding a role to an administrator,
+                        make sure no essential groups will be removed."""
+                    ),
+                }
+            }

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -1,6 +1,6 @@
 # Copyright 2014 ABF OSIELL <http://osiell.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class ResUsers(models.Model):
@@ -18,6 +18,19 @@ class ResUsers(models.Model):
         compute="_compute_role_ids",
         compute_sudo=True,
     )
+
+    @api.onchange("role_line_ids")
+    def _onchange_role_line_ids(self):
+        if self._is_admin():
+            return {
+                "warning": {
+                    "title": _("Warning"),
+                    "message": _(
+                        """When adding a role to an administrator,
+                    make sure no essential groups will be removed."""
+                    ),
+                }
+            }
 
     @api.model
     def _default_role_lines(self):


### PR DESCRIPTION
When creating a new user role, it is possible to add a user to that role without having added any groups. If this is saved, all that user’s access rights will be wiped and he will not able to login anymore (Internal Server Error). It can cause problems when happens for admin user.