### PR TITLE
[17.0][FIX] base_user_role_company: wrong arguments in new odoo releases

### DIFF
--- a/base_user_role_company/controllers/main.py
+++ b/base_user_role_company/controllers/main.py
@@ -8,8 +8,8 @@ from odoo.addons.web.controllers.home import Home
 
 class HomeExtended(Home):
     @http.route()
-    def web_load_menus(self, unique):
-        response = super().web_load_menus(unique)
+    def web_load_menus(self, *args, **kwargs):
+        response = super().web_load_menus(*args, **kwargs)
         # On logout & re-login we could see wrong menus being rendered
         # To avoid this, menu http cache must be disabled
         response.headers.remove("Cache-Control")


### PR DESCRIPTION
In new releases of odoo17 a new argument has been added to the `web_load_menus` function

https://github.com/odoo/odoo/blob/f360eb2f008cdc9de88f3db058dd24085b5be499/addons/web/controllers/home.py#L66