### PR TITLE
[FIX] base_user_role_company: fix column_invisible

### DIFF
--- a/base_user_role_company/views/role.xml
+++ b/base_user_role_company/views/role.xml
@@ -12,7 +12,7 @@
                 expr="//field[@name='role_line_ids']//field[@name='role_id']"
                 position="after"
             >
-                <field name="allowed_company_ids" invisible="1" />
+                <field name="allowed_company_ids" column_invisible="1" />
                 <field name="company_id" groups="base.group_multi_company" />
             </xpath>
         </field>


### PR DESCRIPTION
On 17.0, `invisible="1"` doesn't remove the column, I replaced by `column_invisible="1"`