### PR TITLE
[16.0][FW] base_user_role: multiple ports from 15.0

### DIFF
--- a/.oca/oca-port/blacklist/base_user_role.json
+++ b/.oca/oca-port/blacklist/base_user_role.json
@@ -1,0 +1,6 @@
+{
+  "pull_requests": {
+    "OCA/server-backend#237": "(auto) Nothing to port from PR #237",
+    "OCA/server-backend#262": "(auto) Nothing to port from PR #262"
+  }
+}

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -138,16 +138,8 @@ class TestUserRole(TransactionCase):
 
     def test_role_unlink(self):
         # Get role1 and role2 groups
-        role1_groups = (
-            self.role1_id.implied_ids
-            | self.role1_id.trans_implied_ids
-            | self.role1_id.group_id
-        )
-        role2_groups = (
-            self.role2_id.implied_ids
-            | self.role2_id.trans_implied_ids
-            | self.role2_id.group_id
-        )
+        role1_groups = self.role1_id.trans_implied_ids | self.role1_id.group_id
+        role2_groups = self.role2_id.trans_implied_ids | self.role2_id.group_id
 
         # Configure the user with role1 and role2
         self.user_id.write(
@@ -174,16 +166,8 @@ class TestUserRole(TransactionCase):
 
     def test_role_line_unlink(self):
         # Get role1 and role2 groups
-        role1_groups = (
-            self.role1_id.implied_ids
-            | self.role1_id.trans_implied_ids
-            | self.role1_id.group_id
-        )
-        role2_groups = (
-            self.role2_id.implied_ids
-            | self.role2_id.trans_implied_ids
-            | self.role2_id.group_id
-        )
+        role1_groups = self.role1_id.trans_implied_ids | self.role1_id.group_id
+        role2_groups = self.role2_id.trans_implied_ids | self.role2_id.group_id
 
         # Configure the user with role1 and role2
         self.user_id.write(

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -137,12 +137,17 @@ class TestUserRole(TransactionCase):
         self.assertEqual(user_group_ids, role_group_ids)
 
     def test_role_unlink(self):
-        # Get role1 groups
-        role1_group_ids = (
-            self.role1_id.implied_ids.ids + self.role1_id.trans_implied_ids.ids
+        # Get role1 and role2 groups
+        role1_groups = (
+            self.role1_id.implied_ids
+            | self.role1_id.trans_implied_ids
+            | self.role1_id.group_id
         )
-        role1_group_ids.append(self.role1_id.group_id.id)
-        role1_group_ids = sorted(set(role1_group_ids))
+        role2_groups = (
+            self.role2_id.implied_ids
+            | self.role2_id.trans_implied_ids
+            | self.role2_id.group_id
+        )
 
         # Configure the user with role1 and role2
         self.user_id.write(
@@ -153,22 +158,32 @@ class TestUserRole(TransactionCase):
                 ]
             }
         )
+        # Check user has groups from role1 and role2
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertLessEqual(role2_groups, self.user_id.groups_id)
         # Remove role2
         self.role2_id.unlink()
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        self.assertEqual(user_group_ids, role1_group_ids)
+        # Check user has groups from only role1
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
         # Remove role1
         self.role1_id.unlink()
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        self.assertEqual(user_group_ids, [])
+        # Check user has no groups from role1 and role2
+        self.assertFalse(role1_groups <= self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
 
     def test_role_line_unlink(self):
-        # Get role1 groups
-        role1_group_ids = (
-            self.role1_id.implied_ids.ids + self.role1_id.trans_implied_ids.ids
+        # Get role1 and role2 groups
+        role1_groups = (
+            self.role1_id.implied_ids
+            | self.role1_id.trans_implied_ids
+            | self.role1_id.group_id
         )
-        role1_group_ids.append(self.role1_id.group_id.id)
-        role1_group_ids = sorted(set(role1_group_ids))
+        role2_groups = (
+            self.role2_id.implied_ids
+            | self.role2_id.trans_implied_ids
+            | self.role2_id.group_id
+        )
 
         # Configure the user with role1 and role2
         self.user_id.write(
@@ -179,18 +194,23 @@ class TestUserRole(TransactionCase):
                 ]
             }
         )
+        # Check user has groups from role1 and role2
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertLessEqual(role2_groups, self.user_id.groups_id)
         # Remove role2 from the user
         self.user_id.role_line_ids.filtered(
             lambda l: l.role_id.id == self.role2_id.id
         ).unlink()
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        self.assertEqual(user_group_ids, role1_group_ids)
+        # Check user has groups from only role1
+        self.assertLessEqual(role1_groups, self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
         # Remove role1 from the user
         self.user_id.role_line_ids.filtered(
             lambda l: l.role_id.id == self.role1_id.id
         ).unlink()
-        user_group_ids = sorted({group.id for group in self.user_id.groups_id})
-        self.assertEqual(user_group_ids, [])
+        # Check user has no groups from role1 and role2
+        self.assertFalse(role1_groups <= self.user_id.groups_id)
+        self.assertFalse(role2_groups <= self.user_id.groups_id)
 
     def test_default_user_roles(self):
         self.default_user.write(

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -261,16 +261,16 @@ class TestUserRole(TransactionCase):
         self.assertFalse(self.user_id.show_alert)
 
     def test_group_groups_into_role(self):
-        user_group_ids = [group.id for group in self.user_id.groups_id]
+        user_group_ids = self.user_id.groups_id.ids
         # Check that there is not a role with name: Test Role
         self.assertFalse(self.role_model.search([("name", "=", "Test Role")]))
         # Call create_role function to group groups into a role
         wizard = self.wiz_model.with_context(active_ids=user_group_ids).create(
             {"name": "Test Role"}
         )
-        wizard.create_role()
+        res = wizard.create_role()
         # Check that a role with name: Test Role has been created
-        new_role = self.role_model.search([("name", "=", "Test Role")])
-        self.assertTrue(new_role)
-        # Check that the role has the correct groups
+        new_role = self.env[res["res_model"]].browse(res["res_id"])
+        self.assertEqual(new_role.name, "Test Role")
+        # Check that the role has the correct groups (even if the order is not equal)
         self.assertEqual(set(new_role.implied_ids.ids), set(user_group_ids))


### PR DESCRIPTION
Port from 15.0 to 16.0:
- #181
- #266

The following PRs have been blacklisted:
- #237: (auto) Nothing to port
- #262: (auto) Nothing to port

Same PR than https://github.com/OCA/server-backend/pull/335 but for 16.0