### PR TITLE
[FIX] base_user_role_company: Do not auto install this module.

### DIFF
--- a/base_user_role_company/__manifest__.py
+++ b/base_user_role_company/__manifest__.py
@@ -14,7 +14,6 @@
         "views/user.xml",
     ],
     "installable": True,
-    "auto_install": True,
     "maintainer": "dreispt",
     "development_status": "Beta",
 }


### PR DESCRIPTION
the _company module is an extra module used in a multi company context (and only in some situation). It is totally useless in mono company. As 2 modules exists, it doesn't makes sense to make the second auto_installable

forward port of https://github.com/OCA/server-backend/pull/340