### PR TITLE
[16.0][IMP] base_portal_type: use boolean field to define portal-group

### DIFF
--- a/base_portal_type/README.rst
+++ b/base_portal_type/README.rst
@@ -47,7 +47,9 @@ Usage
 
 To use this module, you need to:
 
-#. create a group of category ``base_portal_type.category_portal_type``
+#. create a group with either
+    * category set to ``base_portal_type.category_portal_type``
+    * or ``portal`` field set to True, which allows you to organize your portal-groups in other categories
 #. observe the group shows up on a user form for users of type `Portal`
 #. now you can use this group in your frontend templates and code to make some features accessible to this group
 
@@ -78,6 +80,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)
+* Benedikt Zimmer <github@kellerzimmer.net>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_portal_type/__manifest__.py
+++ b/base_portal_type/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     "data": [
         "data/ir_module_category.xml",
+        "views/res_groups_views.xml",
     ],
     "demo": [
         "demo/res_groups.xml",

--- a/base_portal_type/data/ir_module_category.xml
+++ b/base_portal_type/data/ir_module_category.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2023 Hunki Enterprises BV
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0) -->
-<data>
-
-<record id="category_portal_type" model="ir.module.category">
-    <field name="name">Portal type</field>
-</record>
-
-</data>
+<odoo>
+    <record id="category_portal_type" model="ir.module.category">
+        <field name="name">Portal type</field>
+    </record>
+</odoo>

--- a/base_portal_type/demo/res_groups.xml
+++ b/base_portal_type/demo/res_groups.xml
@@ -1,11 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2023 Hunki Enterprises BV
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0) -->
-<data>
-
-<record id="group_portal_type" model="res.groups">
-    <field name="name">A portal type</field>
-    <field name="category_id" ref="category_portal_type" />
-</record>
-
-</data>
+<odoo>
+    <record id="group_portal_type" model="res.groups">
+        <field name="name">A portal type</field>
+        <!-- demonstrating backwards compatibility before introduction of this field -->
+        <field name="portal" eval="False" />
+        <field name="category_id" ref="category_portal_type" />
+    </record>
+    <record id="group_portal_example_1" model="res.groups">
+        <field name="name">Portal Group 1</field>
+        <field name="portal">True</field>
+        <field name="category_id" ref="base.module_category_technical" />
+    </record>
+    <record id="group_portal_example_2" model="res.groups">
+        <field name="name">Portal Group 2</field>
+        <field name="portal">True</field>
+        <field name="category_id" ref="base.module_category_technical" />
+    </record>
+    <record id="group_portal_example_3" model="res.groups">
+        <field name="name">Portal Group 3</field>
+        <field name="portal">True</field>
+        <!-- just to demonstrate that portal groups don't need a category_id and will be put into "Other" section -->
+        <field name="category_id" eval="False" />
+    </record>
+</odoo>

--- a/base_portal_type/models/res_groups.py
+++ b/base_portal_type/models/res_groups.py
@@ -1,16 +1,17 @@
 # Copyright 2023 Hunki Enterprises BV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 
-
 from lxml import etree
 
-from odoo import api, models
+from odoo import api, fields, models
 
 from odoo.addons.base.models.res_users import name_boolean_group, name_selection_groups
 
 
 class ResGroups(models.Model):
     _inherit = "res.groups"
+
+    portal = fields.Boolean("Is Portal Group")
 
     @api.model
     def _update_user_groups_view(self):
@@ -24,57 +25,86 @@ class ResGroups(models.Model):
         ][0]
         portal_group = self.env.ref("base.group_portal")
         internal_group = self.env.ref("base.group_user")
+
+        user_type_field_name = name_selection_groups(user_type_groups.ids)
+        non_public_attrs = str(
+            {
+                "readonly": [
+                    (
+                        user_type_field_name,
+                        "not in",
+                        [internal_group.id, portal_group.id],
+                    )
+                ],
+            }
+        )
+
         portal_groups = (
             self.env["res.groups"]
-            .with_context(lang=None)
             .search(
                 [
+                    "|",
                     (
                         "category_id",
                         "=",
                         self.env.ref("base_portal_type.category_portal_type").id,
                     ),
+                    ("portal", "=", True),
                 ]
             )
+            .with_context(lang=None)
         )
-        user_type_field = name_selection_groups(user_type_groups.ids)
-        for node in arch.xpath("//group/field[@name='%s']" % user_type_field):
-            for group in portal_groups:
-                field_name = name_boolean_group(group.id)
-                for field_node in arch.xpath("//field[@name='%s']" % field_name):
-                    field_node.attrib["attrs"] = str(
-                        {
-                            "readonly": [
-                                (
-                                    user_type_field,
-                                    "not in",
-                                    (portal_group + internal_group).ids,
-                                )
-                            ],
-                        }
-                    )
-                node.addnext(
-                    etree.Element(
-                        "field",
-                        {
-                            "name": field_name,
-                            "on_change": "1",
-                            "attrs": str(
-                                {
-                                    "invisible": [
-                                        (user_type_field, "!=", portal_group.id),
-                                    ],
-                                }
-                            ),
-                        },
-                    )
+
+        # during install/upgrade/uninstall, super()._update_user_groups_view() may return
+        # a placeholder view without the field which has name=user_type_field_name added yet.
+        # Making sure we received the real view here
+        arch_root = arch.xpath("//field[@name='groups_id'][@position='replace']")
+        if len(arch_root) and portal_groups:
+            # as the original construction of the groups view makes all xml-groups
+            # per application invisible, it is 'easier' to create another section for
+            # portal users and append the whole section at the bottom of the view.
+            # name attribute is given here to easily identify this group element in tests
+            portal_group_elem = etree.SubElement(
+                arch_root[0],
+                "group",
+                name="base_portal_type_extension",
+                attrs=str(
+                    {
+                        "readonly": [(user_type_field_name, "!=", portal_group.id)],
+                        "invisible": [(user_type_field_name, "!=", portal_group.id)],
+                    }
+                ),
+            )
+            for app_id, app_name in portal_groups.mapped("category_id").name_get() + [
+                (False, "Other")
+            ]:
+                portal_groups_in_app = portal_groups.filtered(
+                    lambda r: (r.category_id.id or False) == app_id
                 )
-        view_context = dict(self.env.context, lang=None)
-        view_context.pop("install_filename", None)
-        # pylint: disable=context-overridden
-        view.with_context(view_context).write(
-            {"arch": etree.tostring(arch, pretty_print=True, encoding="unicode")}
-        )
+                if not portal_groups_in_app:
+                    continue
+                app_group_elem = etree.SubElement(
+                    portal_group_elem,
+                    "group",
+                    string=app_name,
+                )
+                for group in portal_groups_in_app:
+                    field_name = name_boolean_group(group.id)
+                    for field_node in arch.xpath("//field[@name='%s']" % field_name):
+                        field_node.attrib["attrs"] = non_public_attrs
+                    etree.SubElement(
+                        app_group_elem,
+                        "field",
+                        name=field_name,
+                        on_change="1",
+                    )
+
+            view_context = dict(self.env.context, lang=None)
+            view_context.pop("install_filename", None)
+            # pylint: disable=context-overridden
+            view.with_context(view_context).write(
+                {"arch": etree.tostring(arch, pretty_print=True, encoding="unicode")}
+            )
         return result
 
     @api.model
@@ -82,9 +112,11 @@ class ResGroups(models.Model):
         return [
             (
                 app,
-                kind
-                if app.xml_id != "base_portal_type.category_portal_type"
-                else "boolean",
+                (
+                    kind
+                    if app.xml_id != "base_portal_type.category_portal_type"
+                    else "boolean"
+                ),
                 groups,
                 category,
             )

--- a/base_portal_type/readme/CONTRIBUTORS.rst
+++ b/base_portal_type/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)
+* Benedikt Zimmer <github@kellerzimmer.net>

--- a/base_portal_type/readme/USAGE.rst
+++ b/base_portal_type/readme/USAGE.rst
@@ -1,5 +1,7 @@
 To use this module, you need to:
 
-#. create a group of category ``base_portal_type.category_portal_type``
+#. create a group with either
+    * category set to ``base_portal_type.category_portal_type``
+    * or ``portal`` field set to True, which allows you to organize your portal-groups in other categories
 #. observe the group shows up on a user form for users of type `Portal`
 #. now you can use this group in your frontend templates and code to make some features accessible to this group

--- a/base_portal_type/static/description/index.html
+++ b/base_portal_type/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -396,7 +396,15 @@ Only for development or testing purpose, do not use in production.
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
-<li>create a group of category <tt class="docutils literal">base_portal_type.category_portal_type</tt></li>
+<li><dl class="first docutils">
+<dt>create a group with either</dt>
+<dd><ul class="first last">
+<li>category set to <tt class="docutils literal">base_portal_type.category_portal_type</tt></li>
+<li>or <tt class="docutils literal">portal</tt> field set to True, which allows you to organize your portal-groups in other categories</li>
+</ul>
+</dd>
+</dl>
+</li>
 <li>observe the group shows up on a user form for users of type <cite>Portal</cite></li>
 <li>now you can use this group in your frontend templates and code to make some features accessible to this group</li>
 </ol>
@@ -427,12 +435,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Holger Brunn &lt;<a class="reference external" href="mailto:mail&#64;hunki-enterprises.com">mail&#64;hunki-enterprises.com</a>&gt; (<a class="reference external" href="https://hunki-enterprises.com">https://hunki-enterprises.com</a>)</li>
+<li>Benedikt Zimmer &lt;<a class="reference external" href="mailto:github&#64;kellerzimmer.net">github&#64;kellerzimmer.net</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/base_portal_type/tests/test_base_portal_type.py
+++ b/base_portal_type/tests/test_base_portal_type.py
@@ -11,10 +11,45 @@ from odoo.addons.base.models.res_users import name_boolean_group
 
 class TestBasePortalGroup(TransactionCase):
     def test_portal_group_view(self):
-        """Test that our group is added to the users form twice"""
-        group = self.env.ref("base_portal_type.group_portal_type").copy()
+        """Test that a group is added to the users form twice"""
+        group = self.env["res.groups"].create(
+            {
+                "name": "Test Group",
+                "category_id": self.env.ref("base_portal_type.category_portal_type").id,
+            }
+        )
         group_field_name = name_boolean_group(group.id)
         groups_view = etree.fromstring(self.env.ref("base.user_groups_view").arch)
         self.assertEqual(
             len(groups_view.xpath("//field[@name='%s']" % group_field_name)), 3
         )
+
+
+class TestNoOtherSectionOnView(TransactionCase):
+    def test_portal_group_view_no_other_section(self):
+        """
+        Test that if no portal groups exists without a category_id set,
+        no 'Other' section is created.
+        """
+        self.env["res.groups"].search(
+            [
+                ("portal", "=", True),
+                ("category_id", "=", False),
+            ]
+        ).unlink()
+        # adding a portal group to guarantee the view extension
+        self.env["res.groups"].create(
+            {
+                "name": "Test Group",
+                "portal": True,
+                "category_id": self.env.ref("base_portal_type.category_portal_type").id,
+            }
+        )
+
+        groups_view = etree.fromstring(self.env.ref("base.user_groups_view").arch)
+        group_elem = groups_view.xpath("//group[@name='base_portal_type_extension']")
+
+        # making sure the parent group element actually exists
+        self.assertEqual(len(group_elem), 1)
+        # searching for the 'Other' section, which should not exist after unlinking above
+        self.assertEqual(len(group_elem[0].xpath("//group[@string='Other']")), 0)

--- a/base_portal_type/views/res_groups_views.xml
+++ b/base_portal_type/views/res_groups_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_groups_search_portal" model="ir.ui.view">
+        <field name="name">res.groups.search_portal</field>
+        <field name="inherit_id" ref="base.view_groups_search" />
+        <field name="model">res.groups</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='share']" position="after">
+                <field name="portal" />
+            </xpath>
+            <xpath expr="//filter[@name='filter_no_share']" position="attributes">
+                <attribute name="domain">[
+                    ('share','=',False),
+                    ('portal','=',False),
+                    ('category_id','!=',%(base_portal_type.category_portal_type)d)
+                    ]
+                </attribute>
+            </xpath>
+            <xpath expr="//filter[@name='filter_no_share']" position="after">
+                <filter
+                    name="filter_portal"
+                    string="Portal Groups"
+                    domain="[
+                        '|',
+                        ('portal','=',True),
+                        ('category_id','=',%(base_portal_type.category_portal_type)d)
+                    ]"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_groups_form_portal" model="ir.ui.view">
+        <field name="name">res.groups.form.portal</field>
+        <field name="inherit_id" ref="base.view_groups_form" />
+        <field name="model">res.groups</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='share']" position="after">
+                <field name="portal" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR adjusts the circumstances under which a res.group becomes available for portal users:
In addition to the magic module category in the data.xml of this module, a boolean field 'portal' can be set on a group to make it selectable for portal users.
For backwards compatibility I have kept the module category, though.

This makes it also possible to put portal-groups into actual categories and then have them displayed in those categories on the res.users form view.

It addresses an old/stale/closed issue: https://github.com/OCA/server-backend/issues/232

Not sure if actively pinging the main contributor is best practice or frowned upon, but since this module was initiated by you, maybe you want to take a look :smile: 
@hbrunn 