### PR TITLE
[18.0][FIX] base_user_role: fix field name ambiguity

### DIFF
--- a/base_user_role/models/res_groups.py
+++ b/base_user_role/models/res_groups.py
@@ -21,7 +21,7 @@ class ResGroups(models.Model):
     role_ids = fields.Many2many(
         comodel_name="res.users.role",
         relation="res_groups_implied_roles_rel",
-        string="Roles",
+        string="User Roles",
         compute="_compute_role_ids",
         help="Roles in which the group is involved",
     )
@@ -43,7 +43,7 @@ class ResGroups(models.Model):
         recursive=True,
     )
 
-    role_count = fields.Integer("# Roles", compute="_compute_role_count")
+    role_count = fields.Integer("# User Roles", compute="_compute_role_count")
 
     def _compute_role_count(self):
         for group in self:

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 class ResUsersRole(models.Model):
     _name = "res.users.role"
     _inherits = {"res.groups": "group_id"}
-    _description = "User role"
+    _description = "User Role"
 
     group_id = fields.Many2one(
         comodel_name="res.groups",
@@ -152,7 +152,7 @@ class ResUsersRoleLine(models.Model):
         (
             "user_role_uniq",
             "unique (user_id,role_id)",
-            "Roles can be assigned to a user only once at a time",
+            "User roles can be assigned to a user only once at a time",
         )
     ]
 

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -23,7 +23,7 @@ class ResUsers(models.Model):
 
     role_ids = fields.One2many(
         comodel_name="res.users.role",
-        string="Roles",
+        string="User Roles",
         compute="_compute_role_ids",
         compute_sudo=True,
         groups="base.group_erp_manager",

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -227,7 +227,7 @@ class TestUserRole(TransactionCase):
         # Check that the user cannot read multicompany data again since it lost
         # its admin privileges
         with self.assertRaisesRegex(
-            AccessError, "You are not allowed to access 'User role'"
+            AccessError, "You are not allowed to access 'User Role'"
         ):
             role.read()
 

--- a/base_user_role/views/group.xml
+++ b/base_user_role/views/group.xml
@@ -14,7 +14,11 @@
                         icon="fa-gears"
                         invisible="not role_count"
                     >
-                        <field string="Roles" name="role_count" widget="statinfo" />
+                        <field
+                            string="User Roles"
+                            name="role_count"
+                            widget="statinfo"
+                        />
                     </button>
                 </div>
             </xpath>

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -78,7 +78,7 @@
         <field name="name">res.users.role.search</field>
         <field name="model">res.users.role</field>
         <field name="arch" type="xml">
-            <search string="Roles">
+            <search>
                 <field name="name" />
                 <field name="user_ids" />
                 <field name="implied_ids" />
@@ -86,7 +86,7 @@
         </field>
     </record>
     <record id="action_res_users_role_tree" model="ir.actions.act_window">
-        <field name="name">Roles</field>
+        <field name="name">User Roles</field>
         <field name="res_model">res.users.role</field>
         <field name="path">user-role</field>
         <field name="view_mode">list,form</field>

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -9,7 +9,7 @@
         <field name="inherit_id" ref="base.view_users_form" />
         <field name="arch" type="xml">
             <xpath expr="//notebook/page[1]" position="before">
-                <page string="Roles">
+                <page string="User Roles">
                     <field name="role_ids" invisible="1" />
                     <field name="role_line_ids" nolabel="1">
                         <list editable="bottom" decoration-muted="not is_enabled">

--- a/base_user_role/wizards/create_from_user.py
+++ b/base_user_role/wizards/create_from_user.py
@@ -40,7 +40,7 @@ class WizardCreateRoleFromUser(models.TransientModel):
 
         return {
             "context": self.env.context,
-            "name": "Role",
+            "name": "User Role",
             "view_type": "form",
             "view_mode": "form",
             "res_model": "res.users.role",


### PR DESCRIPTION
Core Odoo defines a `Roles` field on res.partner, which is inherited on res.users.

This gives a recurring warning
```
Two fields (l10n_es_edi_facturae_ac_role_type_ids, role_ids) of res.users() have the same label: Roles. [Modules: None and base_user_role]
```

as well as real ambiguity in the list of views in search and export widgets.

https://github.com/odoo/odoo/blob/18.0/addons/l10n_es_edi_facturae/models/res_partner.py#L20-L21

Propose to change the field name to fix the ambiguity, and update labeling in other places for consistency.