### PR TITLE
[FIX] base_ical: fix res_users._compute_ical_ids

### DIFF
--- a/base_ical/models/res_users.py
+++ b/base_ical/models/res_users.py
@@ -12,7 +12,7 @@ class ResUsers(models.Model):
 
     def _compute_ical_ids(self):
         domain = [("allowed_users_ids", "=", self.env.uid)]
-        self.write({"ical_ids": self.env["base.ical"].search(domain)})
+        self.sudo().write({"ical_ids": self.env["base.ical"].search(domain)})
 
     @property
     def SELF_READABLE_FIELDS(self):

--- a/base_ical/models/res_users.py
+++ b/base_ical/models/res_users.py
@@ -11,8 +11,9 @@ class ResUsers(models.Model):
     ical_ids = fields.One2many("base.ical", compute="_compute_ical_ids")
 
     def _compute_ical_ids(self):
-        domain = [("allowed_users_ids", "=", self.env.uid)]
-        self.sudo().write({"ical_ids": self.env["base.ical"].search(domain)})
+        for this in self:
+            domain = [("allowed_users_ids", "=", this.id)]
+            this.ical_ids = self.env["base.ical"].search(domain)
 
     @property
     def SELF_READABLE_FIELDS(self):


### PR DESCRIPTION
The cal_ids field isn't writable by the user because it's not part of SELF_WRITEABLE_FIELDS hence the normal access check happens and a normal user isn't allowed to write to res.users (the exception only happens if all fields are part of SELF_WRITEABLE_FIELDS).