### PR TITLE
[18.0][FIX] base_external_dbsource_mssql: convert string query to TextClause expected by sqlalchemy

### DIFF
--- a/base_external_dbsource_mssql/models/base_external_dbsource.py
+++ b/base_external_dbsource_mssql/models/base_external_dbsource.py
@@ -4,6 +4,7 @@
 # this is needed to generate connection string
 import pymssql
 import sqlalchemy
+from sqlalchemy import text
 
 from odoo import fields, models
 
@@ -34,6 +35,8 @@ class BaseExternalDbsource(models.Model):
 
     def _execute_mssql(self, sqlquery, sqlparams, metadata):
         rows, cols = list(), list()
+        # Convert to accepted object by sqlalchemy
+        sqlquery = text(sqlquery)
         for record in self:
             with record.connection_open() as connection:
                 if sqlparams is None:


### PR DESCRIPTION
The execute method expects as the query not a plain string, but an object. The easiest is to convert it to a TextClause object: https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execute

Examples are actually provided in the documentation: https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.TextClause