### PR TITLE
[FIX] base_user_role: Order res.users.role per name.

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -12,6 +12,7 @@ class ResUsersRole(models.Model):
     _name = "res.users.role"
     _inherits = {"res.groups": "group_id"}
     _description = "User role"
+    _order = "name"
 
     group_id = fields.Many2one(
         comodel_name="res.groups",


### PR DESCRIPTION
Rational, for the time being, there is no order defined. As a result, displayed are done by id, that doesn't make sense for end users