### PR TITLE
[18.0][FIX] base_user_role: Support dynamic base.group_multi_company

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -66,10 +66,12 @@ class ResUsers(models.Model):
 
     @api.model
     def _get_self_writable_groups(self):
-        group = self.env.ref(
+        groups = self.env.ref("base.group_multi_company")
+        if group := self.env.ref(
             "mail.group_mail_notification_type_inbox", raise_if_not_found=False
-        )
-        return group or self.env["res.groups"]
+        ):
+            groups |= group
+        return groups
 
     def set_groups_from_roles(self, force=False):
         """Set (replace) the groups following the roles defined on users.

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import datetime
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
@@ -211,6 +211,38 @@ class TestUserRole(TransactionCase):
         )
         roles = self.role_model.browse([self.role1_id.id, self.role2_id.id])
         self.assertEqual(user.role_ids, roles)
+
+    def test_group_multi_company_write_link(self):
+        group = self.env.ref("base.group_multi_company")
+        self.assertNotIn(
+            group,
+            self.multicompany_user_2.groups_id,
+            "should not have base.group_multi_company",
+        )
+        self.multicompany_user_2.write(
+            {"company_ids": [Command.link(self.company1.id)]}
+        )
+        self.assertIn(
+            group,
+            self.multicompany_user_2.groups_id,
+            "should have base.group_multi_company",
+        )
+
+    def test_group_multi_company_write_unlink(self):
+        group = self.env.ref("base.group_multi_company")
+        self.assertIn(
+            group,
+            self.multicompany_user_1.groups_id,
+            "should have base.group_multi_company",
+        )
+        self.multicompany_user_1.write(
+            {"company_ids": [Command.unlink(self.company2.id)]}
+        )
+        self.assertNotIn(
+            group,
+            self.multicompany_user_1.groups_id,
+            "should not have base.group_multi_company",
+        )
 
     def test_role_multicompany(self):
         """Test AccessError when admin-like user accesses a role"""


### PR DESCRIPTION
Per the `create` and `write` methods on the `res.users` model [^1], `base.group_multi_company` group membership is a derivative of company membership.

[^1]: https://github.com/odoo/odoo/blob/2c2641a0d725e3548328e756fd8b9301308a3f6c/odoo/addons/base/models/res_users.py#L1902-L1930