### PR TITLE
[18.0][UPD] base_user_role: prevents deletion of roles in use

### DIFF
--- a/base_user_role/i18n/de.po
+++ b/base_user_role/i18n/de.po
@@ -437,6 +437,18 @@ msgid "Wizard to add multiple users to a role"
 msgstr ""
 
 #. module: base_user_role
+#. odoo-python
+#: code:addons/base_user_role/models/role.py:0
+msgid ""
+"You cannot delete a role that is still assigned to one or "
+"more users. Please remove the users from the role(s) "
+"before deleting. Roles in use: %s"
+msgstr ""
+"Sie können eine Rolle nicht löschen, die noch einem oder mehreren Benutzern "
+"zugewiesen ist. Bitte entfernen Sie die Benutzer aus der/den Rolle(n), "
+"bevor Sie löschen. Rollen in Verwendung: %s"
+
+#. module: base_user_role
 #: model_terms:ir.ui.view,arch_db:base_user_role.create_from_user_wizard_view
 msgid "or"
 msgstr "oder"

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 
 from odoo import SUPERUSER_ID, _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -98,6 +99,21 @@ class ResUsersRole(models.Model):
         return res
 
     def unlink(self):
+        # Check if any of the roles being deleted are still assigned to users
+        role_lines = self.env["res.users.role.line"].search(
+            [("role_id", "in", self.ids)]
+        )
+        if role_lines:
+            # Get role names for better error message
+            role_names = ", ".join(role_lines.mapped("role_id.name"))
+            raise UserError(
+                _(
+                    "You cannot delete a role that is still assigned to one or "
+                    "more users. Please remove the users from the role(s) "
+                    "before deleting. Roles in use: %s"
+                )
+                % role_names
+            )
         users = self.mapped("user_ids")
         res = super().unlink()
         users.set_groups_from_roles(force=True)

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -3,7 +3,7 @@
 import datetime
 
 from odoo import fields
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
@@ -154,12 +154,20 @@ class TestUserRole(TransactionCase):
         # Check user has groups from role1 and role2
         self.assertLessEqual(role1_groups, self.user_id.groups_id)
         self.assertLessEqual(role2_groups, self.user_id.groups_id)
-        # Remove role2
+        # Remove role2 from user before unlinking
+        self.user_id.role_line_ids.filtered(
+            lambda rl: rl.role_id.id == self.role2_id.id
+        ).unlink()
+        # Now unlink role2
         self.role2_id.unlink()
         # Check user has groups from only role1
         self.assertLessEqual(role1_groups, self.user_id.groups_id)
         self.assertFalse(role2_groups <= self.user_id.groups_id)
-        # Remove role1
+        # Remove role1 from user before unlinking
+        self.user_id.role_line_ids.filtered(
+            lambda rl: rl.role_id.id == self.role1_id.id
+        ).unlink()
+        # Now unlink role1
         self.role1_id.unlink()
         # Check user has no groups from role1 and role2
         self.assertFalse(role1_groups <= self.user_id.groups_id)
@@ -196,6 +204,18 @@ class TestUserRole(TransactionCase):
         # Check user has no groups from role1 and role2
         self.assertFalse(role1_groups <= self.user_id.groups_id)
         self.assertFalse(role2_groups <= self.user_id.groups_id)
+
+    def test_role_unlink_with_users_assigned(self):
+        """Test that deleting a role with assigned users raises UserError."""
+        # Assign role1 to a user
+        self.user_id.write({"role_line_ids": [(0, 0, {"role_id": self.role1_id.id})]})
+
+        # Try to delete the role - should raise UserError
+        with self.assertRaisesRegex(
+            UserError,
+            "You cannot delete a role that is still assigned to one or " "more users",
+        ):
+            self.role1_id.unlink()
 
     def test_default_user_roles(self):
         self.default_user.write(


### PR DESCRIPTION
## What does this change do?

This PR implements a validation mechanism that prevents the deletion of user roles that are still assigned to active users. 
The implementation adds a pre-deletion check to the `res.users.role` model's `unlink()` method by searching for any `res.users.role.line` records that link users to the roles being deleted.
If such records are found, a `UserError` is raised with a descriptive message indicating which roles cannot be deleted because they are still in use.

**Technical Details:**
- Override the `unlink()` method in the `ResUsersRole` model to intercept deletion attempts
- Query the `res.users.role.line` intermediary table before executing the deletion
- If role assignments exist, raise a `UserError` with role names for better user feedback
- The error message is translatable and includes the names of roles that are currently assigned to users
- If no role assignments exist, the deletion proceeds normally via `super().unlink()`

## Why is this change being introduced?

**Business Context:**
Previously, user roles could be deleted even when they were actively assigned to users, leading to inconsistent states and confusion. 

**Compliance & Stability:**
- Enhances system stability by preventing orphaned role assignments
- Ensures data consistency by blocking deletion of roles with active user assignments
- Provides clear, actionable error messages to guide users in the proper deletion workflow
- Meets OCA contribution guidelines for production-stable modules

## Which modules are affected?

- **base_user_role** (primary): Core implementation of the deletion validation
  - `models/role.py`: Added `unlink()` method override to `ResUsersRole` class
  - `i18n/de.po`: Added German translation for the error message
