### PR TITLE
[19.0] [FIX] base_user_role: Fixes group view inheritance to show "User Roles" button

### DIFF
--- a/base_user_role/views/group.xml
+++ b/base_user_role/views/group.xml
@@ -5,23 +5,17 @@
         <field name="model">res.groups</field>
         <field name="inherit_id" ref="base.view_groups_form" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet/group" position="before">
-                <div name="button_box" class="oe_button_box">
-                    <button
-                        class="oe_stat_button"
-                        name="action_view_roles"
-                        type="object"
-                        icon="fa-gears"
-                        invisible="not role_count"
-                    >
-                        <field
-                            string="User Roles"
-                            name="role_count"
-                            widget="statinfo"
-                        />
-                    </button>
-                </div>
-            </xpath>
+            <div name="button_box" position="inside">
+                <button
+                    class="oe_stat_button"
+                    name="action_view_roles"
+                    type="object"
+                    icon="fa-gears"
+                    invisible="not role_count"
+                >
+                    <field string="User Roles" name="role_count" widget="statinfo" />
+                </button>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
In V18 and older, the group form view had a button to access which roles the group is applied per role:

<img width="1070" height="435" alt="image" src="https://github.com/user-attachments/assets/73e7f5df-7bc6-4e1a-b5b6-e7bf3dda9c3a" />


<img width="1220" height="224" alt="image" src="https://github.com/user-attachments/assets/3720c321-79b9-4224-9604-0b6e6cc426b0" />

This button isn't present on V19, currently:

<img width="1206" height="729" alt="image" src="https://github.com/user-attachments/assets/ee45f543-2e32-421a-85b1-0062d5f87868" />

This PR should fix this regression by changing the inheritance, as the newer Odoo version includes the required section to add buttons. 