### PR TITLE
[18.0][FIX] base_user_role: don't trigger constraint res_users_notification_type

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -102,6 +102,16 @@ class ResUsers(models.Model):
             to_remove = [(3, gr) for gr in groups_to_remove]
             groups = to_remove + to_add
             if groups:
-                vals = {"groups_id": groups}
+                # Prevent tiggering res_users_notification_type for share users
+                vals = {}
+                if (
+                    self.env.ref("base.group_user").id in groups_to_remove
+                    and "notification_type" in user._fields
+                    and user.notification_type == "inbox"
+                ):
+                    vals["notification_type"] = "email"
+                    pass
+
+                vals["groups_id"] = groups
                 super(ResUsers, user).write(vals)
         return True

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -4,17 +4,16 @@ import datetime
 
 from odoo import fields
 from odoo.exceptions import AccessError
+from odoo.fields import Command
 from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestUserRole(TransactionCase):
+class TestUserRoleCommon(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(
-            context=dict(cls.env.context, tracking_disable=True, no_reset_password=True)
-        )
         cls.user_model = cls.env["res.users"]
         cls.role_model = cls.env["res.users.role"]
         cls.wiz_model = cls.env["wizard.groups.into.role"]
@@ -83,6 +82,8 @@ class TestUserRole(TransactionCase):
             }
         )
 
+
+class TestUserRole(TestUserRoleCommon):
     def test_role_1(self):
         self.user_id.write({"role_line_ids": [(0, 0, {"role_id": self.role1_id.id})]})
         user_group_ids = sorted({group.id for group in self.user_id.groups_id})
@@ -232,18 +233,6 @@ class TestUserRole(TransactionCase):
         ):
             role.read()
 
-    @tagged("-at_install", "post_install")
-    def test_notification_type_not_reset(self):
-        """Test that roles don't reset notification settings."""
-        if self.env["ir.module.module"]._get("mail").state != "installed":
-            self.skipTest("Mail module is not installed.")
-        notification_group = self.env.ref("mail.group_mail_notification_type_inbox")
-        self.assertNotIn(notification_group, self.user_id.groups_id)
-        self.user_id.notification_type = "inbox"
-        self.assertIn(notification_group, self.user_id.groups_id)
-        self.user_id.write({"role_line_ids": [(0, 0, {"role_id": self.role1_id.id})]})
-        self.assertIn(notification_group, self.user_id.groups_id)
-
     def test_create_role_from_user(self):
         # Use a wizard instance to create a new role based on the user.
         # We use assign_to_user = False, as otherwise this module forcibly
@@ -287,3 +276,60 @@ class TestUserRole(TransactionCase):
         self.assertEqual(new_role.name, "Test Role")
         # Check that the role has the correct groups (even if the order is not equal)
         self.assertEqual(set(new_role.implied_ids.ids), set(user_group_ids))
+
+
+@tagged("post_install", "-at_install")
+class TestUserRoleMail(TestUserRoleCommon):
+    def test_notification_type_not_reset(self):
+        """Test that roles don't reset notification settings."""
+        if self.env["ir.module.module"]._get("mail").state != "installed":
+            self.skipTest("Mail module is not installed.")
+        notification_group = self.env.ref("mail.group_mail_notification_type_inbox")
+        self.assertNotIn(notification_group, self.user_id.groups_id)
+        self.user_id.notification_type = "inbox"
+        self.assertIn(notification_group, self.user_id.groups_id)
+        self.user_id.write(
+            {"role_line_ids": [Command.create({"role_id": self.role1_id.id})]}
+        )
+        self.assertIn(notification_group, self.user_id.groups_id)
+
+    def test_notification_type_reset(self):
+        """When user is demoted to share user, update notification settings.
+
+        The issue only occurs when the writing user is not the superuser, and
+        if an intermittent flush is triggered by for instance
+        `_check_one_user_type` in website's res.users override. This triggers
+        constraint res_users_notification_type as Odoo has not yet recomputed
+        this at that point.
+        """
+        # Notification settings depend on mail being installed
+        if self.env["ir.module.module"]._get("mail").state != "installed":
+            self.skipTest("Mail module is not installed.")
+
+        # Set up a non-superuser user
+        admin_user = self.env["res.users"].create(
+            {
+                "name": "Some admin",
+                "login": "admin@example.com",
+            },
+        )
+        admin_user.groups_id += self.env.ref("base.group_system")
+
+        self.user_id.write(
+            {
+                "role_line_ids": [Command.create({"role_id": self.role1_id.id})],
+                "notification_type": "inbox",
+            },
+        )
+
+        # As non-superuser, delete all roles from the user
+        user = self.user_id.with_user(admin_user)
+        user.write(
+            {
+                "role_line_ids": [
+                    Command.delete(rl.id) for rl in self.user_id.role_line_ids
+                ],
+            },
+        )
+        # Database constraint has not been triggered
+        self.assertEqual(user.notification_type, "email")


### PR DESCRIPTION
How to reproduce
===============

Having the `website` module installed, and a user with some roles and notification type set to `inbox`, delete the roles from the user and save.

Expected result
=============

Roles are removed from the user.

Actual result
===========

```
ERROR: new row for relation "res_users" violates check constraint "res_users_notification_type"
```

Analysis
=======

Notification_type `inbox` is not allowed when the user is no longer has the share flag (which is set for users without group `base.group_user`). This is implemened as a database constraint. The constraint is triggered by the intermittent flush caused by *website*'s `_check_one_user_type` code constraint on `res.users` which gets called earlier than the recompute of `notification_type`.

Fixes

```
  File "/home/odoo/src/oca-server-backend/base_user_role/tests/test_user_role.py", line 312, in test_notification_type_reset
    user.write(
  File "/home/odoo/odoo/18.0/odoo/addons/auth_totp_mail/models/res_users.py", line 11, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/addons/auth_signup/models/res_users.py", line 362, in write
    return super().write(vals)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/addons/mail/models/discuss/res_users.py", line 17, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/addons/mail/models/res_users.py", line 108, in write
    write_res = super(Users, self).write(vals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/addons/resource/models/res_users.py", line 17, in write
    rslt = super().write(vals)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/oca-server-backend/base_user_role/models/user.py", line 60, in write
    res = super().write(vals)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 1920, in write
    res = super(UsersView, self).write(values)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 1609, in write
    return super(UsersImplied, self).write(values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 759, in write
    res = super(Users, self).write(values)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4812, in write
    field.write(self, value)
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 4552, in write
    self.write_batch([(records, value)])
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 4573, in write_batch
    self.write_real(records_commands_list, create)
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 4769, in write_real
    flush()
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 4720, in flush
    comodel.browse(to_delete).unlink()
  File "/home/odoo/src/oca-server-backend/base_user_role/models/role.py", line 180, in unlink
    users.set_groups_from_roles(force=True)
  File "/home/odoo/src/oca-server-backend/base_user_role/models/user.py", line 121, in set_groups_from_roles
    super(ResUsers, user).write(vals)
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 1920, in write
    res = super(UsersView, self).write(values)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 1611, in write
    res = super(UsersImplied, self.with_context(no_add_implied_groups=True)).write(values)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/addons/base/models/res_users.py", line 759, in write
    res = super(Users, self).write(values)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4834, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 1631, in _validate_fields
    check(self)
  File "/home/odoo/odoo/18.0/odoo/addons/website/models/res_users.py", line 105, in _check_one_user_type
    internal_users = self.env.ref('base.group_user').users & self
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 3102, in __get__
    return super().__get__(records, owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 1274, in __get__
    recs._fetch_field(self)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4119, in _fetch_field
    self.fetch(fnames)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4157, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4268, in _fetch_query
    field.read(fetched)
  File "/home/odoo/odoo/18.0/odoo/odoo/fields.py", line 5063, in read
    for id1, id2 in records.env.execute_query(query.select(sql_id1, sql_id2)):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/18.0/odoo/odoo/api.py", line 992, in execute_query
    self.flush_query(query)
  File "/home/odoo/odoo/18.0/odoo/odoo/api.py", line 984, in flush_query
    self[model_name].flush_model(field_names)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 6773, in flush_model
    self._flush(fnames)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 6851, in _flush
    model.browse(some_ids)._write_multi(vals_list)
  File "/home/odoo/odoo/18.0/odoo/odoo/models.py", line 4937, in _write_multi
    self.env.execute_query(SQL(
  File "/home/odoo/odoo/18.0/odoo/odoo/api.py", line 993, in execute_query
    self.cr.execute(query)
  File "/home/odoo/odoo/18.0/odoo/odoo/sql_db.py", line 364, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.CheckViolation: new row for relation "res_users" violates check constraint "res_users_notification_type"
DETAIL:  Failing row contains (81, 1, 151, t, 2026-02-10 15:41:40.105622, user_test_roles, null, null, 1, 84, <p data-o-mail-quote="1">--<br data-o-mail-quote="1">USER TEST (..., t, 2026-02-10 15:41:40.105622, null, f, inbox, null, null, null, null).
```

Also fixes `tagged` being applied to individual test methods, where it is not effective.