### PR TITLE
[19.0][FIX] base_user_role: Cannot see User Roles in list view, even though the user has roles in form view

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -21,10 +21,10 @@ class ResUsers(models.Model):
         for user in self:
             user.show_alert = user.role_line_ids.filtered(lambda rec: rec.is_enabled)
 
-    role_ids = fields.One2many(
+    user_role_ids = fields.One2many(
         comodel_name="res.users.role",
-        string="User Roles",
-        compute="_compute_role_ids",
+        string="Roles",
+        compute="_compute_user_role_ids",
         compute_sudo=True,
         groups="base.group_erp_manager",
     )
@@ -42,9 +42,9 @@ class ResUsers(models.Model):
         return [{"role_id": r.id} for r in default_roles]
 
     @api.depends("role_line_ids.role_id")
-    def _compute_role_ids(self):
+    def _compute_user_role_ids(self):
         for user in self:
-            user.role_ids = user.role_line_ids.mapped("role_id")
+            user.user_role_ids = user.role_line_ids.mapped("role_id")
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -208,7 +208,7 @@ class TestUserRole(TransactionCase):
             {"name": "USER TEST (DEFAULT ROLES)", "login": "user_test_default_roles"}
         )
         roles = self.role_model.browse([self.role1_id.id, self.role2_id.id])
-        self.assertEqual(user.role_ids, roles)
+        self.assertEqual(user.user_role_ids, roles)
 
     def test_role_multicompany(self):
         """Test AccessError when admin-like user accesses a role"""

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -10,12 +10,12 @@
         <field name="arch" type="xml">
             <xpath expr="//notebook/page[1]" position="before">
                 <page string="User Roles">
-                    <field name="role_ids" invisible="1" />
+                    <field name="user_role_ids" invisible="1" />
                     <field name="role_line_ids" nolabel="1">
                         <list editable="bottom" decoration-muted="not is_enabled">
                             <field
                                 name="role_id"
-                                domain="[('id', 'not in', parent.role_ids)]"
+                                domain="[('id', 'not in', parent.user_role_ids)]"
                             />
                             <field name="date_from" />
                             <field name="date_to" />
@@ -52,7 +52,7 @@
         <field name="arch" type="xml">
             <field name="company_ids" position="after">
                 <field
-                    name="role_ids"
+                    name="user_role_ids"
                     filter_domain="[('role_line_ids.role_id.name','ilike',self)]"
                 />
             </field>
@@ -63,7 +63,7 @@
         <field name="inherit_id" ref="base.view_users_tree" />
         <field name="arch" type="xml">
             <field name="role" position="after">
-                <field name="role_ids" widget="many2many_tags" />
+                <field name="user_role_ids" widget="many2many_tags" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
**Summary**
Currently, native Odoo already defines a `role_ids` field (m2m). This overrides the `role_ids` field (o2m) from the `base_user_role` module, which causes the User Roles field to be empty in the User list view.

**Changes**
Renamed `role_ids` field to `user_role_ids`.

**Reproduce:**
Create a User and set a role for the User
<img width="1830" height="996" alt="image" src="https://github.com/user-attachments/assets/7ec20317-b712-4dfd-b0dd-8bcc7d94646f" />


Back to User list view -> User Roles is empty
<img width="1830" height="996" alt="image" src="https://github.com/user-attachments/assets/5d12e5c2-97be-436a-acfa-d7b5412e22af" />