### PR TITLE
[IMP] base_user_role: use new optional feature to display role_ids fi…

### DIFF
--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -64,7 +64,7 @@
         <field name="inherit_id" ref="base.view_users_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="before">
-                <field name="role_ids" widget="many2many_tags" />
+                <field name="role_ids" widget="many2many_tags" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
…elds, in user tree view.

Rational: If user has a lot of roles, the display will be ugly. So we use optional='hide', to have the possibility to show the roles, if required