### PR TITLE
[17.0][FIX] base_user_role: don't reset notification_type

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -63,6 +63,13 @@ class ResUsers(models.Model):
 
     def _get_enabled_roles(self):
         return self.role_line_ids.filtered(lambda rec: rec.is_enabled)
+    
+    @api.model
+    def _get_self_writable_groups(self):
+        group = self.env.ref(
+            "mail.group_mail_notification_type_inbox", raise_if_not_found=False
+        )
+        return group or self.env["res.groups"]
 
     def set_groups_from_roles(self, force=False):
         """Set (replace) the groups following the roles defined on users.
@@ -80,16 +87,17 @@ class ResUsers(models.Model):
                     + role.trans_implied_ids.ids
                 )
             )
+        self_writable_group_ids = self._get_self_writable_groups().ids
         for user in self:
             if not user.role_line_ids and not force:
                 continue
-            group_ids = []
+            user_group_ids = set(user.groups_id.ids).difference(self_writable_group_ids)
+            group_ids = set()
             for role_line in user._get_enabled_roles():
                 role = role_line.role_id
-                group_ids += role_groups[role]
-            group_ids = list(set(group_ids))  # Remove duplicates IDs
-            groups_to_add = list(set(group_ids) - set(user.groups_id.ids))
-            groups_to_remove = list(set(user.groups_id.ids) - set(group_ids))
+                group_ids.update(role_groups[role])
+            groups_to_add = group_ids - user_group_ids
+            groups_to_remove = user_group_ids - group_ids
             to_add = [(4, gr) for gr in groups_to_add]
             to_remove = [(3, gr) for gr in groups_to_remove]
             groups = to_remove + to_add

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -4,6 +4,7 @@ import datetime
 
 from odoo import fields
 from odoo.exceptions import AccessError
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
@@ -231,6 +232,18 @@ class TestUserRole(TransactionCase):
         ):
             role.read()
 
+    @tagged("-at_install", "post_install")
+    def test_notification_type_not_reset(self):
+        """Test that roles don't reset notification settings."""
+        if self.env["ir.module.module"]._get("mail").state != "installed":
+            self.skipTest("Mail module is not installed.")
+        notification_group = self.env.ref("mail.group_mail_notification_type_inbox")
+        self.assertNotIn(notification_group, self.user_id.groups_id)
+        self.user_id.notification_type = "inbox"
+        self.assertIn(notification_group, self.user_id.groups_id)
+        self.user_id.write({"role_line_ids": [(0, 0, {"role_id": self.role1_id.id})]})
+        self.assertIn(notification_group, self.user_id.groups_id)
+        
     def test_create_role_from_user(self):
         # Use a wizard instance to create a new role based on the user.
         # We use assign_to_user = False, as otherwise this module forcibly


### PR DESCRIPTION
Hi ! 
This PR backports to 17.0 the fix introduced by @jhemono in 18.0 (see PR #372), so that the same behavior is available in 17.0 as well.

