### PR TITLE
[19.0][IMP] base_user_role: remove active field from res.users.role.line

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -145,7 +145,6 @@ class ResUsersRoleLine(models.Model):
     _name = "res.users.role.line"
     _description = "Users associated to a role"
 
-    active = fields.Boolean(related="user_id.active")
     role_id = fields.Many2one(
         comodel_name="res.users.role", required=True, string="Role", ondelete="cascade"
     )


### PR DESCRIPTION
- Role lines for archived users silently disappear from the role form view, making it impossible to audit role assignments.
- The field is not used in any view, business logic, or test

@qrtl QT6433