### PR TITLE
[18.0][FIX] base_user_role: remove active field from res.users.role.line

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -21,7 +21,10 @@ class ResUsersRole(models.Model):
         string="Associated group",
     )
     line_ids = fields.One2many(
-        comodel_name="res.users.role.line", inverse_name="role_id", string="Role lines"
+        comodel_name="res.users.role.line",
+        inverse_name="role_id",
+        string="Role lines",
+        domain=[("user_id.active", "=", True)],
     )
     user_ids = fields.One2many(
         comodel_name="res.users", string="Users list", compute="_compute_user_ids"
@@ -134,7 +137,6 @@ class ResUsersRoleLine(models.Model):
     _name = "res.users.role.line"
     _description = "Users associated to a role"
 
-    active = fields.Boolean(related="user_id.active")
     role_id = fields.Many2one(
         comodel_name="res.users.role", required=True, string="Role", ondelete="cascade"
     )


### PR DESCRIPTION
The `active` field was added in PR #167  to exclude archived users from the role list view count. However, it causes Odoo's active_test filtering to silently hide role lines of archived users from the role form view, making it impossible to audit role assignments.

Replace it with a domain on `line_ids` to filter archived users without the active_test side effect.

@qrtl QT6433