### PR TITLE
[14.0][FIX] server_action_navigate: address deprecation warning

### DIFF
--- a/server_action_navigate/models/ir_actions_server.py
+++ b/server_action_navigate/models/ir_actions_server.py
@@ -62,10 +62,9 @@ class IrActionsServer(models.Model):
         self.navigate_line_ids[-1].unlink()
         self.navigate_action_id = False
 
-    @api.model
-    def run_action_navigate_multi(self, action, eval_context=None):
+    def _run_action_navigate_multi(self, eval_context=None):
         IrModel = self.env["ir.model"]
-        lines = action.navigate_line_ids
+        lines = self.navigate_line_ids
         if not lines:
             raise UserError(
                 _("The Action Server %s is not correctly set\n" " : No fields defined")
@@ -76,13 +75,13 @@ class IrActionsServer(models.Model):
         domain = "[('id','in',[" + ",".join(map(str, item_ids)) + "])]"
 
         # Use Defined action if defined
-        if action.navigate_action_id:
-            return_action = action.navigate_action_id
+        if self.navigate_action_id:
+            return_action = self.navigate_action_id
             result = return_action.read()[0]
             result["domain"] = domain
         else:
             # Otherwise, return a default action
-            model_name = action.max_navigate_line_model
+            model_name = self.max_navigate_line_model
             model = IrModel.search([("model", "=", model_name)])
             view_mode = "tree,form"
             result = {


### PR DESCRIPTION
This fixes the following warning

```
2026-03-31 12:15:07,363 1 WARNING devel odoo.addons.base.models.ir_actions: RPC-public action methods are deprecated, found 'run_action_navigate_multi' (in class odoo.addons.server_action_navigate.models.ir_actions_server.IrActionsServer) 
```