### PR TITLE
[FIX] base_user_role: don't reset notification_type

### DIFF
--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "User roles",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.1",
     "category": "Tools",
     "author": "ABF OSIELL, Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -60,6 +60,13 @@ class ResUsers(models.Model):
     def _get_enabled_roles(self):
         return self.role_line_ids.filtered(lambda rec: rec.is_enabled)
 
+    @api.model
+    def _get_self_writable_groups(self):
+        group = self.env.ref(
+            "mail.group_mail_notification_type_inbox", raise_if_not_found=False
+        )
+        return group or self.env["res.groups"]
+
     def set_groups_from_roles(self, force=False):
         """Set (replace) the groups following the roles defined on users.
         If no role is defined on the user, its groups are let untouched unless
@@ -71,6 +78,7 @@ class ResUsers(models.Model):
         for role in self.mapped("role_line_ids.role_id"):
             # v19: use transitive implied groups provided by ORM
             role_groups[role] = list(set(role.all_implied_ids.ids))
+        self_writable_group_ids = self._get_self_writable_groups().ids
         for user in self:
             if not user.role_line_ids and not force:
                 continue
@@ -91,8 +99,9 @@ class ResUsers(models.Model):
                 )
                 if other_admins == 0:
                     group_ids.append(admin_group.id)
-            groups_to_add = list(set(group_ids) - set(user.group_ids.ids))
-            groups_to_remove = list(set(user.group_ids.ids) - set(group_ids))
+            user_group_ids = set(user.group_ids.ids).difference(self_writable_group_ids)
+            groups_to_add = list(set(group_ids) - user_group_ids)
+            groups_to_remove = list(user_group_ids - set(group_ids))
             to_add = [fields.Command.link(gr) for gr in groups_to_add]
             to_remove = [fields.Command.unlink(gr) for gr in groups_to_remove]
             groups = to_remove + to_add


### PR DESCRIPTION
## Problem

The 19.0 migration of `base_user_role` dropped the
`_get_self_writable_groups` method that was present in 18.0. This method
excluded `mail.group_mail_notification_type_inbox` from the role
enforcement logic in `set_groups_from_roles`.

The result is that any user with roles assigned can never persistently set
their notification preference to "In Odoo" — it gets reset on every
`write()` call to `res.users`, or at latest on the next run of the
`cron_update_users` scheduled action.

## Solution

Restore `_get_self_writable_groups` from the 18.0 implementation and use
it in `set_groups_from_roles` to exclude `mail.group_mail_notification_type_inbox`
from both sides of the group diff, exactly as was done before the
migration.

## References

- Migration PR that introduced the regression: #382