### PR TITLE
[18.0][IMP] base_user_role: add a sequence on role and role line

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -12,7 +12,9 @@ class ResUsersRole(models.Model):
     _name = "res.users.role"
     _inherits = {"res.groups": "group_id"}
     _description = "User Role"
+    _order = "sequence,id"
 
+    sequence = fields.Integer(default=10)
     group_id = fields.Many2one(
         comodel_name="res.groups",
         required=True,
@@ -133,7 +135,9 @@ class ResUsersRole(models.Model):
 class ResUsersRoleLine(models.Model):
     _name = "res.users.role.line"
     _description = "Users associated to a role"
+    _order = "sequence,id"
 
+    sequence = fields.Integer(related="role_id.sequence")
     active = fields.Boolean(related="user_id.active")
     role_id = fields.Many2one(
         comodel_name="res.users.role", required=True, string="Role", ondelete="cascade"

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -12,7 +12,7 @@ class ResUsersRole(models.Model):
     _name = "res.users.role"
     _inherits = {"res.groups": "group_id"}
     _description = "User Role"
-    _order = "sequence,id"
+    _order = "sequence,name"
 
     sequence = fields.Integer(default=10)
     group_id = fields.Many2one(
@@ -135,9 +135,12 @@ class ResUsersRole(models.Model):
 class ResUsersRoleLine(models.Model):
     _name = "res.users.role.line"
     _description = "Users associated to a role"
-    _order = "sequence,id"
+    _order = "sequence,name"
 
     sequence = fields.Integer(related="role_id.sequence")
+    # name is used in _order (see above) to sort lines
+    # the same way roles are sorted.
+    name = fields.Char(related="role_id.name")
     active = fields.Boolean(related="user_id.active")
     role_id = fields.Many2one(
         comodel_name="res.users.role", required=True, string="Role", ondelete="cascade"

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -75,7 +75,7 @@
         <field name="name">res.users.role.list</field>
         <field name="model">res.users.role</field>
         <field name="arch" type="xml">
-            <list>
+            <list default_order="sequence,name">
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="user_ids" />

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -76,6 +76,7 @@
         <field name="model">res.users.role</field>
         <field name="arch" type="xml">
             <list>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="user_ids" />
             </list>


### PR DESCRIPTION
When there is a few roles, created upon time, it may becomes quite handy to be able to sort them is a "logical" order like with increased rights or so.
This PR allows it.