### PR TITLE
[18.0][IMP] base_user_role_profile: add a sequence on role profile

### DIFF
--- a/base_user_role_profile/models/res_users_profile.py
+++ b/base_user_role_profile/models/res_users_profile.py
@@ -6,7 +6,9 @@ from odoo import fields, models
 class ResUsersProfile(models.Model):
     _name = "res.users.profile"
     _description = "Role profile"
+    _order = "sequence,id"
 
+    sequence = fields.Integer(default=10)
     name = fields.Char()
     user_ids = fields.Many2many(
         "res.users",

--- a/base_user_role_profile/models/res_users_profile.py
+++ b/base_user_role_profile/models/res_users_profile.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 class ResUsersProfile(models.Model):
     _name = "res.users.profile"
     _description = "Role profile"
-    _order = "sequence,id"
+    _order = "sequence,name"
 
     sequence = fields.Integer(default=10)
     name = fields.Char()

--- a/base_user_role_profile/views/res_users_profile_views.xml
+++ b/base_user_role_profile/views/res_users_profile_views.xml
@@ -21,6 +21,7 @@
         <field name="model">res.users.profile</field>
         <field name="arch" type="xml">
             <list>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
             </list>
         </field>

--- a/base_user_role_profile/views/res_users_profile_views.xml
+++ b/base_user_role_profile/views/res_users_profile_views.xml
@@ -20,7 +20,7 @@
         <field name="name">res.users.profile.list</field>
         <field name="model">res.users.profile</field>
         <field name="arch" type="xml">
-            <list>
+            <list default_order="sequence,name">
                 <field name="sequence" widget="handle" />
                 <field name="name" />
             </list>


### PR DESCRIPTION
When there is a few profiles, created upon time, it may becomes quite handy to be able to sort them is a "logical" order like with increased rights or so.
This PR allows it.